### PR TITLE
fix: normalize portable artifact paths and preserve local resume

### DIFF
--- a/o11y_bench/resume.py
+++ b/o11y_bench/resume.py
@@ -76,6 +76,41 @@ def normalize_saved_path(value: Any) -> Any:
     return value
 
 
+def configured_task_name(config: dict[str, Any]) -> str | None:
+    task = config.get("task")
+    if not isinstance(task, dict):
+        return None
+    task_path = task.get("path")
+    if isinstance(task_path, str) and task_path:
+        return Path(task_path).name
+    return None
+
+
+def resolved_trial_task_name(trial_dir: Path, trial_config: dict[str, Any]) -> str:
+    result_payload = load_json_object(trial_dir / "result.json")
+    task_name = result_payload.get("task_name") if isinstance(result_payload, dict) else None
+    if not isinstance(task_name, str) or not task_name:
+        task_name = configured_task_name(trial_config)
+    if isinstance(task_name, str) and task_name:
+        return task_name
+    return trial_dir.name.split("__", 1)[0]
+
+
+def configured_root_path(config: dict[str, Any], key: str) -> Path | None:
+    value = config.get(key)
+    return Path(value) if isinstance(value, str) and value else None
+
+
+def configured_tasks_root(config: dict[str, Any]) -> Path | None:
+    datasets = config.get("datasets")
+    if not isinstance(datasets, list) or not datasets:
+        return None
+    first = datasets[0]
+    if not isinstance(first, dict):
+        return None
+    return configured_root_path(first, "path")
+
+
 def load_json_object(path: Path) -> dict[str, Any] | None:
     try:
         payload = json.loads(path.read_text())
@@ -154,7 +189,7 @@ def patch_job_concurrency_config(
 
 
 def patch_job_paths_for_resume(
-    job_dir: Path, expected_jobs_dir: Path, *, dry_run: bool = False
+    job_dir: Path, expected_jobs_dir: Path, expected_tasks_dir: Path, *, dry_run: bool = False
 ) -> list[str]:
     notes: list[str] = []
     config_path = job_dir / "config.json"
@@ -172,7 +207,9 @@ def patch_job_paths_for_resume(
         notes.append(
             f"{verb} {job_dir.name} config for resume: jobs_dir {current_jobs_dir} -> {expected_jobs_dir_text}"
         )
-    current_trials_dir = str(job_dir.resolve())
+    jobs_root = configured_root_path(config, "jobs_dir")
+    current_trials_dir = str((jobs_root / job_dir.name) if jobs_root else job_dir.resolve())
+    tasks_root = configured_tasks_root(config)
     affected_trial_configs = 0
     skipped_trial_configs = 0
     for trial_dir in sorted(
@@ -185,17 +222,35 @@ def patch_job_paths_for_resume(
         if trial_config is None:
             skipped_trial_configs += 1
             continue
-        if normalize_saved_path(trial_config.get("trials_dir")) == current_trials_dir:
+        task = trial_config.get("task")
+        task_name = resolved_trial_task_name(trial_dir, trial_config)
+        current_task_dir = str(
+            (tasks_root / task_name) if tasks_root else (expected_tasks_dir / task_name).resolve()
+        )
+
+        needs_trials_dir_patch = (
+            normalize_saved_path(trial_config.get("trials_dir")) != current_trials_dir
+        )
+        needs_task_path_patch = (
+            not isinstance(task, dict)
+            or normalize_saved_path(task.get("path")) != current_task_dir
+        )
+        if not needs_trials_dir_patch and not needs_task_path_patch:
             continue
         if not dry_run:
             trial_config["trials_dir"] = current_trials_dir
+            if not isinstance(task, dict):
+                task = {}
+                trial_config["task"] = task
+            task["path"] = current_task_dir
             trial_config_path.write_text(json.dumps(trial_config, indent=4) + "\n")
         affected_trial_configs += 1
 
     if affected_trial_configs:
         verb = "Would patch" if dry_run else "Patched"
+        task_root_display = tasks_root if tasks_root else expected_tasks_dir.resolve()
         notes.append(
-            f"{verb} {affected_trial_configs} trial config(s) for resume: trials_dir -> {current_trials_dir}"
+            f"{verb} {affected_trial_configs} trial config(s) for resume: trials_dir -> {current_trials_dir}, task.path -> {task_root_display}/<task>"
         )
     if skipped_trial_configs:
         verb = "Would skip" if dry_run else "Skipped"
@@ -275,7 +330,10 @@ def plan_job_dir_for_resume(
         )
 
     config_notes_list = patch_job_paths_for_resume(
-        job_dir, Path(expected_fields["jobs_dir"]), dry_run=True
+        job_dir,
+        Path(expected_fields["jobs_dir"]),
+        Path(expected_fields["tasks_path"]),
+        dry_run=True,
     )
     concurrency_note = patch_job_concurrency_config(
         job_dir, expected_fields["n_concurrent_trials"], dry_run=True
@@ -357,7 +415,13 @@ def repair_job_dir_for_resume(
         return notes
 
     plan = plan_job_dir_for_resume(job_dir, expected_fields, task_checksums)
-    notes.extend(patch_job_paths_for_resume(job_dir, Path(expected_fields["jobs_dir"])))
+    notes.extend(
+        patch_job_paths_for_resume(
+            job_dir,
+            Path(expected_fields["jobs_dir"]),
+            Path(expected_fields["tasks_path"]),
+        )
+    )
     concurrency_note = patch_job_concurrency_config(job_dir, expected_fields["n_concurrent_trials"])
     if concurrency_note:
         notes.append(concurrency_note)

--- a/o11y_bench/resume.py
+++ b/o11y_bench/resume.py
@@ -232,8 +232,7 @@ def patch_job_paths_for_resume(
             normalize_saved_path(trial_config.get("trials_dir")) != current_trials_dir
         )
         needs_task_path_patch = (
-            not isinstance(task, dict)
-            or normalize_saved_path(task.get("path")) != current_task_dir
+            not isinstance(task, dict) or normalize_saved_path(task.get("path")) != current_task_dir
         )
         if not needs_trials_dir_patch and not needs_task_path_patch:
             continue

--- a/o11y_bench/run.py
+++ b/o11y_bench/run.py
@@ -23,6 +23,7 @@ from reporting.report_paths import (
 
 from .config import (
     PROVIDERS,
+    ROOT,
     STANDARD_SUITE,
     JobSpec,
     SuiteOpts,
@@ -135,11 +136,184 @@ def _stamp_checksums(job_dir: Path, task_checksums: dict[str, str]) -> None:
                 result_path.write_text(json.dumps(payload, indent=4) + "\n")
 
 
+def _read_json_dict(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _write_json_dict(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=4) + "\n")
+
+
+def _portable_artifact_path(path: Path, fallback: Path) -> str:
+    try:
+        portable = path.resolve().relative_to(ROOT)
+    except ValueError:
+        portable = fallback
+    return portable.as_posix()
+
+
+def _portable_jobs_dir(job_dir: Path) -> str:
+    return _portable_artifact_path(job_dir.parent, Path("jobs") / job_dir.parent.name)
+
+
+def _portable_job_dir(job_dir: Path) -> str:
+    return _portable_artifact_path(job_dir, Path("jobs") / job_dir.parent.name / job_dir.name)
+
+
+def _portable_task_root(tasks_dir: Path) -> str:
+    return _portable_artifact_path(tasks_dir, Path("tasks"))
+
+
+def _portable_task_path(tasks_dir: Path, task_name: str) -> str:
+    return _portable_artifact_path(tasks_dir / task_name, Path("tasks") / task_name)
+
+
+def _configured_task_name(payload: dict[str, Any]) -> str | None:
+    task = payload.get("task")
+    if isinstance(task, dict):
+        task_path = task.get("path")
+        if isinstance(task_path, str) and task_path:
+            return Path(task_path).name
+    return None
+
+
+def _trial_task_name(trial_dir: Path, task_name: str | None) -> str:
+    if isinstance(task_name, str) and task_name:
+        return task_name
+    return trial_dir.name.split("__", 1)[0]
+
+
+def _resolved_trial_task_name(
+    trial_dir: Path,
+    *,
+    result_payload: dict[str, Any] | None = None,
+    config_payload: dict[str, Any] | None = None,
+) -> str:
+    task_name = result_payload.get("task_name") if isinstance(result_payload, dict) else None
+    if not isinstance(task_name, str) or not task_name:
+        task_name = (
+            _configured_task_name(config_payload)
+            if isinstance(config_payload, dict)
+            else None
+        )
+    return _trial_task_name(trial_dir, task_name)
+
+
+def _sanitize_trial_config_payload(
+    payload: dict[str, Any], *, job_dir: Path, trial_dir: Path, tasks_dir: Path, task_name: str | None
+) -> bool:
+    changed = False
+    task_name = _trial_task_name(trial_dir, task_name or _configured_task_name(payload))
+    portable_job_dir = _portable_job_dir(job_dir)
+    portable_task_dir = _portable_task_path(tasks_dir, task_name)
+
+    if payload.get("trials_dir") != portable_job_dir:
+        payload["trials_dir"] = portable_job_dir
+        changed = True
+
+    task = payload.get("task")
+    if isinstance(task, dict) and task.get("path") != portable_task_dir:
+        task["path"] = portable_task_dir
+        changed = True
+
+    return changed
+
+
+def _sanitize_trial_result_payload(
+    payload: dict[str, Any], *, job_dir: Path, trial_dir: Path, tasks_dir: Path
+) -> bool:
+    changed = False
+    task_name = _trial_task_name(trial_dir, payload.get("task_name"))
+    portable_job_dir = _portable_job_dir(job_dir)
+    portable_task_dir = _portable_task_path(tasks_dir, task_name)
+    portable_trial_dir = f"{portable_job_dir}/{trial_dir.name}"
+    portable_trial_uri = f"file:{portable_trial_dir}"
+
+    if payload.get("trial_uri") != portable_trial_uri:
+        payload["trial_uri"] = portable_trial_uri
+        changed = True
+
+    config_payload = payload.get("config")
+    if isinstance(config_payload, dict):
+        if _sanitize_trial_config_payload(
+            config_payload,
+            job_dir=job_dir,
+            trial_dir=trial_dir,
+            tasks_dir=tasks_dir,
+            task_name=task_name,
+        ):
+            changed = True
+
+    task = payload.get("task")
+    if isinstance(task, dict) and task.get("path") != portable_task_dir:
+        task["path"] = portable_task_dir
+        changed = True
+
+    task_id = payload.get("task_id")
+    if isinstance(task_id, dict) and task_id.get("path") != portable_task_dir:
+        task_id["path"] = portable_task_dir
+        changed = True
+
+    return changed
+
+
+def _sanitize_job_artifacts(job_dir: Path, tasks_dir: Path) -> None:
+    config_path = job_dir / "config.json"
+    if config_path.exists():
+        config_payload = _read_json_dict(config_path)
+        if isinstance(config_payload, dict):
+            changed = False
+            portable_jobs_dir = _portable_jobs_dir(job_dir)
+            portable_tasks_dir = _portable_task_root(tasks_dir)
+            if config_payload.get("jobs_dir") != portable_jobs_dir:
+                config_payload["jobs_dir"] = portable_jobs_dir
+                changed = True
+            datasets = config_payload.get("datasets")
+            if isinstance(datasets, list):
+                for dataset in datasets:
+                    if not isinstance(dataset, dict):
+                        continue
+                    if dataset.get("path") != portable_tasks_dir:
+                        dataset["path"] = portable_tasks_dir
+                        changed = True
+            if changed:
+                _write_json_dict(config_path, config_payload)
+
+    for trial_dir in _iter_trial_dirs(job_dir):
+        trial_config_path = trial_dir / "config.json"
+        result_path = trial_dir / "result.json"
+        trial_config = _read_json_dict(trial_config_path) if trial_config_path.exists() else None
+        result_payload = _read_json_dict(result_path) if result_path.exists() else None
+        task_name = _resolved_trial_task_name(
+            trial_dir,
+            result_payload=result_payload,
+            config_payload=trial_config,
+        )
+        if isinstance(trial_config, dict) and _sanitize_trial_config_payload(
+                trial_config,
+                job_dir=job_dir,
+                trial_dir=trial_dir,
+                tasks_dir=tasks_dir,
+                task_name=task_name,
+            ):
+            _write_json_dict(trial_config_path, trial_config)
+
+        if isinstance(result_payload, dict) and _sanitize_trial_result_payload(
+            result_payload, job_dir=job_dir, trial_dir=trial_dir, tasks_dir=tasks_dir
+        ):
+            _write_json_dict(result_path, result_payload)
+
+
 def finalize_job_dir(job_dir: Path, tasks_dir: Path, task_checksums: dict[str, str]) -> Path | None:
     """Stamp checksums and generate per-job HTML report."""
     if not job_dir.exists():
         return None
     _stamp_checksums(job_dir, task_checksums)
+    _sanitize_job_artifacts(job_dir, tasks_dir)
     if not run_report.load_trials(job_dir):
         return None
     report_path = run_report_output_path(job_dir)

--- a/o11y_bench/run.py
+++ b/o11y_bench/run.py
@@ -196,15 +196,18 @@ def _resolved_trial_task_name(
     task_name = result_payload.get("task_name") if isinstance(result_payload, dict) else None
     if not isinstance(task_name, str) or not task_name:
         task_name = (
-            _configured_task_name(config_payload)
-            if isinstance(config_payload, dict)
-            else None
+            _configured_task_name(config_payload) if isinstance(config_payload, dict) else None
         )
     return _trial_task_name(trial_dir, task_name)
 
 
 def _sanitize_trial_config_payload(
-    payload: dict[str, Any], *, job_dir: Path, trial_dir: Path, tasks_dir: Path, task_name: str | None
+    payload: dict[str, Any],
+    *,
+    job_dir: Path,
+    trial_dir: Path,
+    tasks_dir: Path,
+    task_name: str | None,
 ) -> bool:
     changed = False
     task_name = _trial_task_name(trial_dir, task_name or _configured_task_name(payload))
@@ -294,12 +297,12 @@ def _sanitize_job_artifacts(job_dir: Path, tasks_dir: Path) -> None:
             config_payload=trial_config,
         )
         if isinstance(trial_config, dict) and _sanitize_trial_config_payload(
-                trial_config,
-                job_dir=job_dir,
-                trial_dir=trial_dir,
-                tasks_dir=tasks_dir,
-                task_name=task_name,
-            ):
+            trial_config,
+            job_dir=job_dir,
+            trial_dir=trial_dir,
+            tasks_dir=tasks_dir,
+            task_name=task_name,
+        ):
             _write_json_dict(trial_config_path, trial_config)
 
         if isinstance(result_payload, dict) and _sanitize_trial_result_payload(

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -37,7 +37,8 @@ def test_patch_job_paths_for_resume_restores_absolute_trial_paths(tmp_path: Path
 
     payload = json.loads((job_dir / "demo-task__abc1234" / "config.json").read_text())
     assert notes == [
-        f"Patched 1 trial config(s) for resume: trials_dir -> {job_dir.resolve()}, task.path -> {tasks_dir.resolve()}/<task>"
+        "Patched 1 trial config(s) for resume: "
+        f"trials_dir -> {job_dir.resolve()}, task.path -> {tasks_dir.resolve()}/<task>"
     ]
     assert payload["trials_dir"] == str(job_dir.resolve())
     assert payload["task"]["path"] == str((tasks_dir / "demo-task").resolve())
@@ -51,7 +52,8 @@ def test_patch_job_paths_for_resume_dry_run_reports_needed_trial_path_repairs(
     notes = resume.patch_job_paths_for_resume(job_dir, jobs_dir, tasks_dir, dry_run=True)
 
     assert notes == [
-        f"Would patch 1 trial config(s) for resume: trials_dir -> {job_dir.resolve()}, task.path -> {tasks_dir.resolve()}/<task>"
+        "Would patch 1 trial config(s) for resume: "
+        f"trials_dir -> {job_dir.resolve()}, task.path -> {tasks_dir.resolve()}/<task>"
     ]
     payload = json.loads((job_dir / "demo-task__abc1234" / "config.json").read_text())
     assert payload["trials_dir"] == "jobs/demo-job"
@@ -121,7 +123,8 @@ def test_patch_job_paths_for_resume_matches_relative_job_config_paths(tmp_path: 
 
     payload = json.loads((trial_dir / "config.json").read_text())
     assert notes == [
-        f"Patched 1 trial config(s) for resume: trials_dir -> {job_dir.resolve()}, task.path -> tasks/<task>"
+        "Patched 1 trial config(s) for resume: "
+        f"trials_dir -> {job_dir.resolve()}, task.path -> tasks/<task>"
     ]
     assert payload["trials_dir"] == str(job_dir.resolve())
     assert payload["task"]["path"] == f"tasks/{task_name}"

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,127 @@
+import json
+from pathlib import Path
+
+from o11y_bench import resume
+
+
+def _write_resume_fixture(tmp_path: Path) -> tuple[Path, Path, Path]:
+    tasks_dir = tmp_path / "tasks"
+    (tasks_dir / "demo-task" / "tests").mkdir(parents=True)
+    (tasks_dir / "demo-task" / "tests" / "problem.yaml").write_text("prompt: test\n")
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "demo-job"
+    trial_dir = job_dir / "demo-task__abc1234"
+    trial_dir.mkdir(parents=True)
+
+    (job_dir / "config.json").write_text(
+        json.dumps({"jobs_dir": str(jobs_dir.resolve()), "datasets": []}, indent=4)
+    )
+    (trial_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "trials_dir": "jobs/demo-job",
+                "task": {"path": "tasks/demo-task"},
+            },
+            indent=4,
+        )
+    )
+
+    return tasks_dir, jobs_dir, job_dir
+
+
+def test_patch_job_paths_for_resume_restores_absolute_trial_paths(tmp_path: Path) -> None:
+    tasks_dir, jobs_dir, job_dir = _write_resume_fixture(tmp_path)
+
+    notes = resume.patch_job_paths_for_resume(job_dir, jobs_dir, tasks_dir)
+
+    payload = json.loads((job_dir / "demo-task__abc1234" / "config.json").read_text())
+    assert notes == [
+        f"Patched 1 trial config(s) for resume: trials_dir -> {job_dir.resolve()}, task.path -> {tasks_dir.resolve()}/<task>"
+    ]
+    assert payload["trials_dir"] == str(job_dir.resolve())
+    assert payload["task"]["path"] == str((tasks_dir / "demo-task").resolve())
+
+
+def test_patch_job_paths_for_resume_dry_run_reports_needed_trial_path_repairs(
+    tmp_path: Path,
+) -> None:
+    tasks_dir, jobs_dir, job_dir = _write_resume_fixture(tmp_path)
+
+    notes = resume.patch_job_paths_for_resume(job_dir, jobs_dir, tasks_dir, dry_run=True)
+
+    assert notes == [
+        f"Would patch 1 trial config(s) for resume: trials_dir -> {job_dir.resolve()}, task.path -> {tasks_dir.resolve()}/<task>"
+    ]
+    payload = json.loads((job_dir / "demo-task__abc1234" / "config.json").read_text())
+    assert payload["trials_dir"] == "jobs/demo-job"
+    assert payload["task"]["path"] == "tasks/demo-task"
+
+
+def test_patch_job_paths_for_resume_uses_full_task_id_from_result_json(tmp_path: Path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    task_name = "traceql-discover-orders-error-attributes"
+    (tasks_dir / task_name / "tests").mkdir(parents=True)
+    (tasks_dir / task_name / "tests" / "problem.yaml").write_text("prompt: test\n")
+
+    jobs_dir = tmp_path / "jobs"
+    job_dir = jobs_dir / "demo-job"
+    trial_dir = job_dir / "traceql-discover-orders-error-at__abc1234"
+    trial_dir.mkdir(parents=True)
+
+    (job_dir / "config.json").write_text(
+        json.dumps({"jobs_dir": str(jobs_dir.resolve()), "datasets": []}, indent=4)
+    )
+    (trial_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "trials_dir": "jobs/demo-job",
+                "task": {"path": "tasks/traceql-discover-orders-error-at"},
+            },
+            indent=4,
+        )
+    )
+    (trial_dir / "result.json").write_text(json.dumps({"task_name": task_name}, indent=4))
+
+    resume.patch_job_paths_for_resume(job_dir, jobs_dir, tasks_dir)
+
+    payload = json.loads((trial_dir / "config.json").read_text())
+    assert payload["task"]["path"] == str((tasks_dir / task_name).resolve())
+
+
+def test_patch_job_paths_for_resume_matches_relative_job_config_paths(tmp_path: Path) -> None:
+    task_name = "traceql-discover-orders-error-attributes"
+    jobs_dir = tmp_path / "jobs"
+    tasks_dir = tmp_path / "tasks"
+    (tasks_dir / task_name / "tests").mkdir(parents=True)
+    (tasks_dir / task_name / "tests" / "problem.yaml").write_text("prompt: test\n")
+
+    job_dir = jobs_dir / "demo-job"
+    trial_dir = job_dir / "traceql-discover-orders-error-at__abc1234"
+    trial_dir.mkdir(parents=True)
+
+    (job_dir / "config.json").write_text(
+        json.dumps(
+            {"jobs_dir": str(jobs_dir.resolve()), "datasets": [{"path": "tasks"}]},
+            indent=4,
+        )
+    )
+    (trial_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "trials_dir": str(job_dir.resolve()),
+                "task": {"path": str((tasks_dir / "traceql-discover-orders-error-at").resolve())},
+            },
+            indent=4,
+        )
+    )
+    (trial_dir / "result.json").write_text(json.dumps({"task_name": task_name}, indent=4))
+
+    notes = resume.patch_job_paths_for_resume(job_dir, jobs_dir, tasks_dir)
+
+    payload = json.loads((trial_dir / "config.json").read_text())
+    assert notes == [
+        f"Patched 1 trial config(s) for resume: trials_dir -> {job_dir.resolve()}, task.path -> tasks/<task>"
+    ]
+    assert payload["trials_dir"] == str(job_dir.resolve())
+    assert payload["task"]["path"] == f"tasks/{task_name}"

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -170,7 +170,10 @@ def test_finalize_job_dir_sanitizes_artifact_paths(monkeypatch, tmp_path) -> Non
     assert saved_job["datasets"][0]["path"] == "tasks"
     assert saved_trial["task"]["path"] == "tasks/promql-error-rate"
     assert saved_trial["trials_dir"] == "jobs/suite/openai-gpt-5-4-nano-off-k1"
-    assert saved_result["trial_uri"] == "file:jobs/suite/openai-gpt-5-4-nano-off-k1/promql-error-rate__abc123"
+    assert (
+        saved_result["trial_uri"]
+        == "file:jobs/suite/openai-gpt-5-4-nano-off-k1/promql-error-rate__abc123"
+    )
     assert saved_result["config"]["task"]["path"] == "tasks/promql-error-rate"
     assert saved_result["config"]["trials_dir"] == "jobs/suite/openai-gpt-5-4-nano-off-k1"
     assert saved_result["task_id"]["path"] == "tasks/promql-error-rate"

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -110,6 +110,137 @@ def test_execute_job_resumes_from_saved_config(monkeypatch, tmp_path) -> None:
     ]
 
 
+def test_finalize_job_dir_sanitizes_artifact_paths(monkeypatch, tmp_path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    task_dir = tasks_dir / "promql-error-rate"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "tests" / "problem.yaml").write_text("prompt: test\n")
+
+    jobs_dir = tmp_path / "nested" / "suite"
+    job_dir = jobs_dir / "openai-gpt-5-4-nano-off-k1"
+    trial_dir = job_dir / "promql-error-rate__abc123"
+    trial_dir.mkdir(parents=True)
+
+    (job_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "job_name": job_dir.name,
+                "jobs_dir": str(jobs_dir.resolve()),
+                "datasets": [{"path": str(tasks_dir.resolve())}],
+            }
+        )
+    )
+    (trial_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "task": {"path": str(task_dir.resolve())},
+                "trials_dir": str(job_dir.resolve()),
+            }
+        )
+    )
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "trial_uri": trial_dir.resolve().as_uri(),
+                "task_name": "promql-error-rate",
+                "task_id": {"path": str(task_dir.resolve())},
+                "task_checksum": "old",
+                "config": {
+                    "task": {"path": str(task_dir.resolve())},
+                    "trials_dir": str(job_dir.resolve()),
+                },
+                "task": {"path": str(task_dir.resolve())},
+                "agent_info": {"model_info": {"name": "openai/gpt-5.4-nano"}},
+                "agent_result": {"metadata": {"reasoning_effort": "off"}},
+            }
+        )
+    )
+
+    monkeypatch.setattr(run.run_report, "load_trials", lambda job_dir: [{}])
+    monkeypatch.setattr(run.run_report, "write_report", lambda *args, **kwargs: None)
+
+    report_path = run.finalize_job_dir(job_dir, tasks_dir, {"promql-error-rate": "new"})
+
+    saved_job = json.loads((job_dir / "config.json").read_text())
+    saved_trial = json.loads((trial_dir / "config.json").read_text())
+    saved_result = json.loads((trial_dir / "result.json").read_text())
+
+    assert report_path == job_dir / "run_report.html"
+    assert saved_job["jobs_dir"] == "jobs/suite"
+    assert saved_job["datasets"][0]["path"] == "tasks"
+    assert saved_trial["task"]["path"] == "tasks/promql-error-rate"
+    assert saved_trial["trials_dir"] == "jobs/suite/openai-gpt-5-4-nano-off-k1"
+    assert saved_result["trial_uri"] == "file:jobs/suite/openai-gpt-5-4-nano-off-k1/promql-error-rate__abc123"
+    assert saved_result["config"]["task"]["path"] == "tasks/promql-error-rate"
+    assert saved_result["config"]["trials_dir"] == "jobs/suite/openai-gpt-5-4-nano-off-k1"
+    assert saved_result["task_id"]["path"] == "tasks/promql-error-rate"
+    assert saved_result["task"]["path"] == "tasks/promql-error-rate"
+    assert saved_result["task_checksum"] == "new"
+
+
+def test_finalize_job_dir_preserves_full_task_id_in_trial_config(monkeypatch, tmp_path) -> None:
+    tasks_dir = tmp_path / "tasks"
+    task_name = "traceql-discover-orders-error-attributes"
+    task_dir = tasks_dir / task_name
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "tests" / "problem.yaml").write_text("prompt: test\n")
+
+    jobs_dir = tmp_path / "nested" / "suite"
+    job_dir = jobs_dir / "openai-gpt-5-4-nano-off-k1"
+    trial_dir = job_dir / "traceql-discover-orders-error-at__abc1234"
+    truncated_task_name = trial_dir.name.split("__", 1)[0]
+    truncated_task_path = str((tasks_dir / truncated_task_name).resolve())
+    trial_dir.mkdir(parents=True)
+
+    (job_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "job_name": job_dir.name,
+                "jobs_dir": str(jobs_dir.resolve()),
+                "datasets": [{"path": str(tasks_dir.resolve())}],
+            }
+        )
+    )
+    (trial_dir / "config.json").write_text(
+        json.dumps(
+            {
+                "task": {"path": truncated_task_path},
+                "trials_dir": str(job_dir.resolve()),
+            }
+        )
+    )
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "trial_uri": trial_dir.resolve().as_uri(),
+                "task_name": task_name,
+                "task_id": {"path": str(task_dir.resolve())},
+                "task_checksum": "old",
+                "config": {
+                    "task": {"path": truncated_task_path},
+                    "trials_dir": str(job_dir.resolve()),
+                },
+                "task": {"path": str(task_dir.resolve())},
+                "agent_info": {"model_info": {"name": "openai/gpt-5.4-nano"}},
+                "agent_result": {"metadata": {"reasoning_effort": "off"}},
+            }
+        )
+    )
+
+    monkeypatch.setattr(run.run_report, "load_trials", lambda job_dir: [{}])
+    monkeypatch.setattr(run.run_report, "write_report", lambda *args, **kwargs: None)
+
+    run.finalize_job_dir(job_dir, tasks_dir, {task_name: "new"})
+
+    saved_trial = json.loads((trial_dir / "config.json").read_text())
+    saved_result = json.loads((trial_dir / "result.json").read_text())
+
+    assert saved_trial["task"]["path"] == f"tasks/{task_name}"
+    assert saved_result["config"]["task"]["path"] == f"tasks/{task_name}"
+    assert saved_result["task"]["path"] == f"tasks/{task_name}"
+    assert saved_result["task_id"]["path"] == f"tasks/{task_name}"
+
+
 @pytest.mark.parametrize(
     ("dry_run", "expected_events", "expected_preflight_calls"),
     [


### PR DESCRIPTION
This way the HF sync is consistent
- Added functions to resolve task names and paths from trial configurations.
- Updated `patch_job_paths_for_resume` to handle task paths and trials directory correctly.
- Introduced new tests to validate the behavior of the resume functionality, ensuring proper path restoration and configuration updates.
- Enhanced artifact path sanitization in `finalize_job_dir` to maintain consistency across job and trial configurations.
