### PR TITLE
calibrate canonical queries from 0/3 and 3/3 audit findings

### DIFF
--- a/docker/python/src/o11y_stack/generate_data.py
+++ b/docker/python/src/o11y_stack/generate_data.py
@@ -162,7 +162,7 @@ class IncidentConfig:
         """Return error rate for a service at a given time."""
         if self.error_spike_start <= ts <= self.error_spike_end:
             if service == "payment-service":
-                return 0.25  # 25% errors
+                return 0.50  # 50% errors — payment-service owns the spike
             if service == "order-service":
                 return 0.15  # 15% cascading errors
             if service == "api-gateway":

--- a/docker/python/src/o11y_stack/generate_data.py
+++ b/docker/python/src/o11y_stack/generate_data.py
@@ -162,7 +162,7 @@ class IncidentConfig:
         """Return error rate for a service at a given time."""
         if self.error_spike_start <= ts <= self.error_spike_end:
             if service == "payment-service":
-                return 0.50  # 50% errors — payment-service owns the spike
+                return 0.70  # 70% errors — payment-service owns the spike with margin
             if service == "order-service":
                 return 0.15  # 15% cascading errors
             if service == "api-gateway":

--- a/docker/python/src/o11y_stack/generate_data.py
+++ b/docker/python/src/o11y_stack/generate_data.py
@@ -183,16 +183,23 @@ class IncidentConfig:
     def get_slow_probability(self, ts: datetime, path: str) -> float:
         """Return probability that a request at this timestamp/path is flagged slow.
 
-        During the order-service latency incident, /api/orders is the dominant slow
-        path (checkout flow stalls hardest); other order-service endpoints see only
-        a mild uptick so the hotspot is unambiguous when counting >1s request logs.
+        Slow requests are concentrated in two latency incidents:
+        - Order-service latency incident (~6h before end): /api/orders dominates.
+        - User-service cache-refresh incident (~9h before end): /api/users slow.
+
+        A small baseline (1%) keeps healthy periods realistic without letting
+        background noise outweigh the incident spike in a 6h query window. This
+        gives the canonical queries a deterministic, unambiguous dominant slow
+        path regardless of which wall-clock end-time the 6h window sits at.
         """
         if self.latency_start <= ts <= self.latency_end:
             if path == "/api/orders":
                 return 0.60
             if path in ("/api/products", "/api/cart"):
                 return 0.10
-        return 0.05  # baseline slow-request rate
+        if self.cache_refresh_start <= ts <= self.cache_refresh_end and path == "/api/users":
+            return 0.40
+        return 0.01  # small baseline slow rate for realism, not enough to dominate
 
     def get_cache_refresh_lag(self, ts: datetime, service: str) -> int:
         """Synthetic cache refresh lag around the user-service incident."""

--- a/docker/python/src/o11y_stack/generate_data.py
+++ b/docker/python/src/o11y_stack/generate_data.py
@@ -180,6 +180,20 @@ class IncidentConfig:
                 return 2.0  # Upstream services affected
         return 1.0
 
+    def get_slow_probability(self, ts: datetime, path: str) -> float:
+        """Return probability that a request at this timestamp/path is flagged slow.
+
+        During the order-service latency incident, /api/orders is the dominant slow
+        path (checkout flow stalls hardest); other order-service endpoints see only
+        a mild uptick so the hotspot is unambiguous when counting >1s request logs.
+        """
+        if self.latency_start <= ts <= self.latency_end:
+            if path == "/api/orders":
+                return 0.60
+            if path in ("/api/products", "/api/cart"):
+                return 0.10
+        return 0.05  # baseline slow-request rate
+
     def get_cache_refresh_lag(self, ts: datetime, service: str) -> int:
         """Synthetic cache refresh lag around the user-service incident."""
         if service != "user-service":
@@ -810,8 +824,9 @@ def generate_all_data() -> dict[str, ServiceMetrics]:
 
                     error_rate = incidents.get_error_rate(req_ts, target_service)
                     latency_mult = incidents.get_latency_multiplier(req_ts, target_service)
+                    slow_prob = incidents.get_slow_probability(req_ts, endpoint["path"])
                     is_error = random.random() < error_rate
-                    is_slow = random.random() < 0.05
+                    is_slow = random.random() < slow_prob
 
                     base_duration_ms = (
                         random.randint(500, 3000) if is_slow else random.randint(10, 50)

--- a/docker/python/src/o11y_stack/generate_data.py
+++ b/docker/python/src/o11y_stack/generate_data.py
@@ -821,7 +821,7 @@ def generate_all_data() -> dict[str, ServiceMetrics]:
             # Generate requests/logs/traces once per minute
             if current_minute != last_minute:
                 last_minute = current_minute
-                num_requests = max(1, int(traffic * 3))
+                num_requests = max(1, int(traffic * 6))
 
                 for _ in range(num_requests):
                     req_ts = current + timedelta(seconds=random.uniform(0, 59))

--- a/tasks-spec/grafana_api/inspect-dashboard-queries.yaml
+++ b/tasks-spec/grafana_api/inspect-dashboard-queries.yaml
@@ -81,7 +81,6 @@ checks:
         - http_requests_total
         functions:
         - rate
-        - sum
     - title: P95 Latency
       type: timeseries
       datasource_type: prometheus

--- a/tasks-spec/grafana_api/inspect-dashboard-queries.yaml
+++ b/tasks-spec/grafana_api/inspect-dashboard-queries.yaml
@@ -66,12 +66,32 @@ checks:
     - title: Request Rate
       type: timeseries
       datasource_type: prometheus
+      query:
+        language: promql
+        metric_names:
+        - http_requests_total
+        functions:
+        - rate
     - title: Error Rate
       type: stat
       datasource_type: prometheus
+      query:
+        language: promql
+        metric_names:
+        - http_requests_total
+        functions:
+        - rate
+        - sum
     - title: P95 Latency
       type: timeseries
       datasource_type: prometheus
+      query:
+        language: promql
+        metric_names:
+        - http_request_duration_seconds_bucket
+        functions:
+        - histogram_quantile
+        - rate
   name: Service Overview exists with the expected saved panel/query structure
 rubric:
 - criterion: The final response accurately reports the saved Service Overview queries rather than guessed PromQL

--- a/tasks-spec/investigation/payments-path-root-cause.yaml
+++ b/tasks-spec/investigation/payments-path-root-cause.yaml
@@ -26,13 +26,13 @@ rubric:
   fact:
     kind: query
     backend: loki
-    query: sum(count_over_time({job=~".+"} | json | __error__="" | path="/api/payments" | status >= 500 [6h]))
+    query: sum(count_over_time({job=~"user-service|order-service|payment-service"} | json | __error__="" | path="/api/payments" | status >= 500 [6h]))
 - criterion: The final response states Payments-path share of all 5xx request logs accurately.
   weight: 25
   fact:
     kind: query
     backend: loki
-    query: sum(count_over_time({job=~".+"} | json | __error__="" | path="/api/payments" | status >= 500 [6h])) / sum(count_over_time({job=~".+"} | json | __error__="" | status >= 500 [6h]))
+    query: sum(count_over_time({job=~"user-service|order-service|payment-service"} | json | __error__="" | path="/api/payments" | status >= 500 [6h])) / sum(count_over_time({job=~"user-service|order-service|payment-service"} | json | __error__="" | status >= 500 [6h]))
 - criterion: The final response identifies `/api/payments` as the endpoint carrying the most true 5xx request failures in the window and ties that claim to log evidence rather than only generic incident wording
   weight: 10
 - criterion: The final response identifies `payment-service` as the backend where the representative payments-path trace first fails, not merely an upstream relay layer

--- a/tasks-spec/investigation/retry-backlog-incident.yaml
+++ b/tasks-spec/investigation/retry-backlog-incident.yaml
@@ -9,8 +9,9 @@ tags:
 statement: |
   During the payment-led incident, did retries actually pile up somewhere or was that a false lead?
   Using the last six hours of telemetry, tell me which service owned the main retry backlog, what
-  queue name showed up in the warning logs, about how high the main backlog got, and whether the
-  other service was only smaller spillover.
+  queue name showed up in the warning logs, about how high the main backlog got, and compare the
+  peak backlog on the other service so I can tell whether it was a real co-primary or only smaller
+  spillover.
 checks: []
 rubric:
 - criterion: The final response states Peak payment-service retry backlog accurately.

--- a/tasks-spec/investigation/slow-path-hotspot-correlation.yaml
+++ b/tasks-spec/investigation/slow-path-hotspot-correlation.yaml
@@ -28,16 +28,16 @@ rubric:
   fact:
     kind: query
     backend: loki
-    query: sum(count_over_time({job=~".+"} | json | __error__="" | path="/api/products" | duration_ms >= 1000 [6h]))
+    query: sum(count_over_time({job=~"user-service|order-service|payment-service"} | json | __error__="" | path="/api/orders" | duration_ms >= 1000 [6h]))
 - criterion: The final response states Dominant slow-path share of all >1s request logs accurately.
   weight: 25
   fact:
     kind: query
     backend: loki
-    query: sum(count_over_time({job=~".+"} | json | __error__="" | path="/api/products" | duration_ms >= 1000 [6h])) / sum(count_over_time({job=~".+"} | json | __error__="" | duration_ms >= 1000 [6h]))
-- criterion: The final response identifies `/api/products` as the path contributing the most >1s request logs in the window and ties that ranking to log evidence rather than generic latency wording
+    query: sum(count_over_time({job=~"user-service|order-service|payment-service"} | json | __error__="" | path="/api/orders" | duration_ms >= 1000 [6h])) / sum(count_over_time({job=~"user-service|order-service|payment-service"} | json | __error__="" | duration_ms >= 1000 [6h]))
+- criterion: The final response identifies `/api/orders` as the path contributing the most >1s request logs in the window and ties that ranking to log evidence rather than generic latency wording
   weight: 10
 - criterion: The final response states whether one recurring hotspot shows up across several slow traces or whether the slowness is spread around
   weight: 5
-- criterion: The final response identifies `order-service` and `handle GET /api/products` as the main latency hotspot rather than stopping at an upstream relay span like webapp or api-gateway
+- criterion: The final response identifies `order-service` and `handle POST /api/orders` as the main latency hotspot rather than stopping at an upstream relay span like webapp or api-gateway
   weight: 10

--- a/tasks-spec/prometheus_query/promql-discover-http-metric.yaml
+++ b/tasks-spec/prometheus_query/promql-discover-http-metric.yaml
@@ -16,12 +16,10 @@ statement: |
   include that numeric total (req/s) in your answer so I can sanity-check chart scale.
 rubric:
 - criterion: The final response states Aggregate HTTP request rate accurately.
-  weight: 40
+  weight: 55
   fact:
     kind: query
     backend: prometheus
     query: sum(rate(http_requests_total{job=~"user-service|order-service|payment-service"}[5m]))
-- criterion: The response names http_requests_total
-  weight: 25.0
-- criterion: The response names the job label
-  weight: 20.0
+- criterion: The response recommends `http_requests_total` as the metric and the `job` label to break it down by service, tying that recommendation to what is actually scraped in the environment rather than a generic PromQL textbook answer.
+  weight: 30

--- a/tasks-spec/tempo_query/find-slow-traces.yaml
+++ b/tasks-spec/tempo_query/find-slow-traces.yaml
@@ -17,6 +17,8 @@ rubric:
 - criterion: The final response points to at least one concrete slow trace using a trace id, a named operation, or an explicit duration figure
   weight: 5.0
 - criterion: The final response discusses slow requests using duration or latency wording
-  weight: 22.0
+  weight: 15.0
 - criterion: The final response ties slowness to payment or checkout (path, operation, or checkout wording) and names at least one concrete service in those slow paths, plus either a second service, an upstream or downstream hop, or wording about recurrence or a pattern
-  weight: 23.0
+  weight: 15.0
+- criterion: The final response identifies `order-service` (and ideally the `handle POST /api/orders` operation) as the backend actually carrying the slow checkout requests, not just upstream relays like webapp or api-gateway
+  weight: 10.0

--- a/tasks-spec/tempo_query/traceql-cache-refresh-hotspot.yaml
+++ b/tasks-spec/tempo_query/traceql-cache-refresh-hotspot.yaml
@@ -19,10 +19,10 @@ checks:
     mode: tool_trace_id
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
-- criterion: The final response identifies the dominant user-service operation in the slow GET `/api/users` traces rather than stopping at only a generic service-level summary
-  weight: 20
+- criterion: The final response identifies the `refresh auth cache` span (or an equivalent auth-cache refresh operation) inside user-service as the dominant hotspot on slow GET `/api/users` traces, rather than stopping at only a generic service-level summary
+  weight: 25
 - criterion: The final response names `user-service` and `GET /api/users`
-  weight: 15
+  weight: 10
 - criterion: The final response states whether the same hotspot recurs across several slow traces or only some of them
   weight: 10
 - criterion: Any named hotspot in the final answer is grounded in trace spans or timings from the transcript

--- a/tasks-spec/tempo_query/traceql-tail-latency-bottleneck.yaml
+++ b/tasks-spec/tempo_query/traceql-tail-latency-bottleneck.yaml
@@ -24,8 +24,10 @@ rubric:
 - criterion: The final response frames the issue as tail or high-percentile latency, not only average slowness
   weight: 5.0
 - criterion: The final response frames tail/high-percentile latency or structural trace analysis (operators, spans, or plain-language equivalent)
-  weight: 25.0
+  weight: 20.0
 - criterion: The final response discusses latency or duration with concrete timing wording
-  weight: 30.0
+  weight: 25.0
 - criterion: The final response's bottleneck explanation is supported by the cited slow trace rather than generic latency talk
+  weight: 10.0
+- criterion: The slow trace the response cites is an order-service checkout trace (e.g. `POST /api/orders` or `handle POST /api/orders`), not a trace on some unrelated path
   weight: 10.0


### PR DESCRIPTION
## Summary

Calibration pass triggered by auditing the `full-suite-hf-public` job against strong models (Opus 4.6, Gemini 3.1 Pro, GPT-5.4 — all `high` reasoning). Found:

- **2 tasks where all 3 strong models scored 0/3** — broken canonical (`payments-path-root-cause`, `slow-path-hotspot-correlation`)
- **22 tasks where all 3 strong models passed 3/3** — audited for saturation/grade-inflation
- Follow-on determinism + consistency work once spot-checks exposed run-to-run variance

Per skill guidance: rubric must be **correct + verifiable**, NOT tuned to make models pass. Tasks may remain hard — that's fine — as long as they're theoretically passable from controlled data.

## Commits (13 total)

**Generator fixes (5)**
1. `50f599d` — payment-service error spike 0.25 → 0.50
2. `d2fe577` — `slow-path-hotspot-correlation` generator `get_slow_probability` + canonical LogQL scoping
3. `5928321` — payment-service spike 0.50 → 0.70 for robust dominance across end-time shifts
4. `07527fc` — slow-request injection scoped to incident windows (not uniform baseline)
5. `d47cddf` — double request volume (traffic multiplier 3→6) for tighter per-path share stability

**Task rubric tightening (7)**
6. `f736213` — `promql-discover-http-metric`: replace substring-match rubric with grounded recommendation
7. `0f4ae2f` — `inspect-dashboard-queries`: add per-panel saved-query checks (`metric_names`, `functions`)
8. `1adb45a` — `find-slow-traces`: add grounded order-service hotspot criterion
9. `0f79cdd` — `traceql-cache-refresh-hotspot`: require explicit `refresh auth cache` span naming
10. `aa60799` — `inspect-dashboard-queries`: drop `sum` from functions list (aggregator not a Call node)
11. `36131cd` — `retry-backlog-incident`: clarify comparison wording in statement
12. `cf629b8` — `traceql-tail-latency-bottleneck`: require order-service checkout trace

**Canonical alignment (1)**
13. `71ed230` — `payments-path-root-cause`: scope canonical LogQL to target-service logs (matches slow-path fix)

## Validation (Sonnet-off = skill reference; Opus/Gemini-FL = extra signal)

| Task | Sonnet-off | Gemini-FL-off | Opus-4.6-high | Verdict |
|---|---:|---:|---:|---|
| **payments-path-root-cause** (0/3 → ✓) | 0.70 | 0.35 | 1.00 | Correct + verifiable. Opus 1.0 confirms passable; Sonnet scored share correctly but judge rejected rounded count. |
| **slow-path-hotspot-correlation** (0/3 → ✓) | 0.45 | 0.45 | 0.45 | Correct + verifiable. Models consistently use raw `{job=~\".+\"}` giving 2.3× inflated count vs target-service-scoped canonical. Qualitative answer 100% right (path, service, operation, trace). |
| inspect-dashboard-queries | 1.00 | 1.00 | 1.00 | Correct. State check now requires saved PromQL `metric_names`+`functions` per panel. |
| find-slow-traces | 1.00 | 0.90 | 1.00 | Correct. Added order-service hotspot criterion grounded in generator. |
| traceql-cache-refresh-hotspot | 0.75 | 0.65 | 0.75 | Correct + verifiable. Both Sonnet and Opus miss the injected `refresh auth cache` span unless they scope to cache-refresh window. |
| retry-backlog-incident | 1.00 | 1.00 | 1.00 | Correct. Canonical PromQL on `service_retry_queue_depth` is deterministic. |
| traceql-tail-latency-bottleneck | 1.00 | 0.93 | 1.00 | Correct. Grounded in generator-biased `/api/orders` slow injection. |
| promql-discover-http-metric | 1.00 | 1.00 | 1.00 | Correct. Substring-match weights replaced with grounded-recommendation criterion. |

## Determinism + consistency audit

- Generator calls `random.seed(42)` once in `main()` → same `(seed, scenario_time)` tuple produces **identical hash** across runs (verified via `/tmp/check_determinism.py` → sha256 `c1d3a1a5…`)
- Harbor sets `O11Y_SCENARIO_TIME_ISO` **once per job**, reused across k=3 trials → identical data within a job
- Across jobs (different wall-clock start), `end_time` differs. Post-fixes:
  - `/api/payments` share 30–58% across 6 tested end_times, always dominant, margin ≥3 errors
  - `/api/orders` slow share 53–81%, always dominant, margin ≥3
  - Baseline slow rate 1% (realistic) instead of 5% (noise-dominated)
  - 6× traffic multiplier → ~4000 requests / 24h, halves share variance

## Skill alignment

✓ Canonical facts tied to `generate_data.py`
✓ Canonical `fact:` + single judge call over response parsing
✓ Narrative rubric criterion retained per task
✓ `5[0-9]{2}` / `status>=500` semantics correct
✓ Generator deterministic per `(seed, scenario_time)` tuple
✓ Rubrics correct + theoretically passable, not tuned to make models pass

## Test plan

- [x] `mise run setup:sync` — 63 tasks generated clean
- [x] `mise run test` — 99 tests passing (no regressions)
- [x] Sonnet-off spot-check per fix on live Harbor stack (skill's reference model)
- [x] Opus-4.6-high spot-check as strongest-model reference (extra signal)
- [x] Gemini-3.1-flash-lite spot-check as weak-model reference (since GPT-5.4 endpoints were unreliable this session)
- [x] Determinism check: same seed + end_time → identical hash
- [x] Share stability check across end_time shifts

🤖 Generated with [Claude Code](https://claude.com/claude-code)