### PR TITLE
fix(run_report): stamp __result_path so step-limit trials aren't flagged as invalid

### DIFF
--- a/reporting/run_report.py
+++ b/reporting/run_report.py
@@ -359,6 +359,7 @@ def load_trials(job_dir: Path) -> list[JsonDict]:
             result = json.loads(result_path.read_text())
         except Exception:
             continue
+        result["__result_path"] = str(result_path.resolve())
         if classify_trial_artifact(trial_dir, result) != "complete":
             continue
 


### PR DESCRIPTION
Without __result_path on the result dict, downstream is_invalid_infra_trial
calls can't locate stdout.txt to detect the "Agent exceeded max step limit"
marker, so legitimate step-limit exits were mis-classified as infra failures
and rendered with the "invalid" badge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
