### PR TITLE
feat: add gcx CLI mode via GcxOpenCodeAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,22 @@ Use either `--agent` or `--agent-import-path`, not both.
 The LangChain agent in this repo is intentionally a simple example of wiring a custom Harbor agent
 entrypoint through the existing benchmark flow.
 
+### gcx CLI Mode
+
+By default, agents interact with Grafana through mcp-grafana (MCP tools). To benchmark
+agents using the gcx CLI instead, use the `GcxOpenCodeAgent` agent class:
+
+```bash
+mise run bench:job -- --model anthropic/claude-sonnet-4-6 --task-name query-cpu-metrics --agent-import-path agents.gcx_opencode_agent:GcxOpenCodeAgent
+```
+
+This runs OpenCode with gcx and gcx skills pre-installed in the container, but
+with MCP tools stripped so the agent can only reach Grafana through gcx.
+The container image has `GRAFANA_SERVER` and `GRAFANA_ORG_ID` set so gcx
+connects to the sidecar Grafana automatically.
+
+This agent can only run models available in OpenCode.
+
 ## Running Your Own Models
 
 If your model is reachable through Harbor and LiteLLM, pass it as `provider/model`.

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -10,9 +10,33 @@ only reach Grafana through gcx.
 from typing import Any
 
 from harbor.agents.installed.opencode import OpenCode
+from harbor.models.trajectories import Trajectory
 
 
 class GcxOpenCodeAgent(OpenCode):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.mcp_servers = []
+
+    def _convert_events_to_trajectory(
+        self, events: list[dict[str, Any]]
+    ) -> Trajectory | None:
+        """Inject a synthetic step_finish when the agent was killed mid-step.
+
+        The base class only records a turn when step_finish is seen, so
+        timeouts silently drop the in-progress turn. Here, we force a
+        step_finish if one doesn't exist, so we always write the trajectory,
+        even in the event of a timeout on the job.
+        """
+        if events:
+            has_open_step = False
+            for event in events:
+                etype = event.get("type")
+                if etype == "step_start":
+                    has_open_step = True
+                elif etype == "step_finish":
+                    has_open_step = False
+            if has_open_step:
+                events = [*events, {"type": "step_finish", "part": {}}]
+
+        return super()._convert_events_to_trajectory(events)

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -18,9 +18,7 @@ class GcxOpenCodeAgent(OpenCode):
         super().__init__(*args, **kwargs)
         self.mcp_servers = []
 
-    def _convert_events_to_trajectory(
-        self, events: list[dict[str, Any]]
-    ) -> Trajectory | None:
+    def _convert_events_to_trajectory(self, events: list[dict[str, Any]]) -> Trajectory | None:
         """Inject a synthetic step_finish when the agent was killed mid-step.
 
         The base class only records a turn when step_finish is seen, so

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -1,0 +1,18 @@
+"""OpenCode agent without MCP tools — uses gcx CLI instead.
+
+Harbor passes MCP server configs from task.toml to every agent, including
+built-in ones like opencode. Without this subclass, opencode would have both
+MCP tools (from mcp-grafana) and gcx CLI access, which defeats the purpose of
+benchmarking gcx-only interaction. Clearing mcp_servers ensures the agent can
+only reach Grafana through gcx.
+"""
+
+from typing import Any
+
+from harbor.agents.installed.opencode import OpenCode
+
+
+class GcxOpenCodeAgent(OpenCode):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.mcp_servers = []

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,3 +1,10 @@
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:76c7449e8bd509a860b61eb060599fd9b1750bcbafe28008f769d35db6109a3d
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+
+RUN gcx skills install --all \
+    && mkdir -p ~/.config/opencode/skills \
+    && ln -s ~/.agents/skills/* ~/.config/opencode/skills/
+
 WORKDIR /app

--- a/environment/docker-compose.yaml
+++ b/environment/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       LOKI_URL: "http://o11y-stack-${COMPOSE_PROJECT_NAME}:3100"
       TEMPO_URL: "http://o11y-stack-${COMPOSE_PROJECT_NAME}:3200"
       MCP_URL: "http://o11y-stack-${COMPOSE_PROJECT_NAME}:8080/mcp"
+      GRAFANA_SERVER: "http://o11y-stack-${COMPOSE_PROJECT_NAME}:3000" # for gcx
+      GRAFANA_ORG_ID: "1" # for gcx
     networks:
       harbor-shared: {}
 


### PR DESCRIPTION
## Summary

- Adds a gcx CLI mode for benchmarking agents that interact with Grafana through `gcx` instead of MCP tools
- Installs gcx + gcx skills in the task container Dockerfile, with a symlink so opencode discovers them.
  - **This does mean gcx + skills are installed always. I haven't seen the agents use gcx when the mcp tools are installed, but if there's concern about this causing a diversion for the agents, we can look for another way**
- Adds `GcxOpenCodeAgent` — a thin OpenCode subclass that strips MCP server configs so the agent can only reach Grafana through gcx. If I didn't do this, the agent just calls the MCP tools.
- Sets `GRAFANA_SERVER` and `GRAFANA_ORG_ID` in docker-compose (for gcx) so gcx can connect to the sidecar

### Usage

```bash
mise run bench:job -- --model anthropic/claude-sonnet-4-6 \
  --agent-import-path agents.gcx_opencode_agent:GcxOpenCodeAgent \
  --task-name query-cpu-metrics
```