### PR TITLE
gcx: allow using a local gcx build, instead of a published artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tasks-level2/
 .results-archive
 .cache
 .agents
+environment/gcx

--- a/README.md
+++ b/README.md
@@ -231,6 +231,38 @@ connects to the sidecar Grafana automatically.
 
 This agent can only run models available in OpenCode.
 
+### Using A Local gcx Build
+
+To test gcx changes before they are on main, you can use a locally-built binary
+instead of the published release.
+
+Set `LOCAL_GCX` to the path of your binary when running preflight:
+
+```bash
+LOCAL_GCX=~/path/to/gcx/bin/gcx mise run setup:preflight
+```
+
+Or copy it into the build context manually:
+
+```bash
+cp ~/path/to/gcx/bin/gcx environment/gcx
+mise run setup:preflight
+```
+
+Either way, the Docker image will use your local binary instead of downloading
+from GitHub. The `environment/gcx` file is gitignored and cleaned up after build.
+
+The binary must be a **Linux** executable matching the Docker image architecture.
+If you're on macOS, a native `go build` produces a binary that won't run inside
+the container. Build the binary for linux first:
+
+```bash
+cd ~/workspace/gcx && GOOS=linux GOARCH=arm64 go build -o bin/gcx-linux ./cmd/gcx
+LOCAL_GCX=~/path/to/gcx/bin/gcx-linux mise run setup:preflight
+```
+
+Use `GOARCH=amd64` if your Docker is running x86_64 images.
+
 ## Running Your Own Models
 
 If your model is reachable through Harbor and LiteLLM, pass it as `provider/model`.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,6 @@ instead of the published release.
 
 Set `LOCAL_GCX` to the path of a gcx executable **for Linux** when running preflight or bench runs.
 
-
 When set, the Docker image will use your local binary instead of downloading
 from GitHub. The `environment/gcx` file is gitignored and cleaned up after build.
 

--- a/README.md
+++ b/README.md
@@ -236,32 +236,19 @@ This agent can only run models available in OpenCode.
 To test gcx changes before they are on main, you can use a locally-built binary
 instead of the published release.
 
-Set `LOCAL_GCX` to the path of your binary when running preflight:
+Set `LOCAL_GCX` to the path of a gcx executable **for Linux** when running preflight or bench runs.
 
-```bash
-LOCAL_GCX=~/path/to/gcx/bin/gcx mise run setup:preflight
-```
 
-Or copy it into the build context manually:
-
-```bash
-cp ~/path/to/gcx/bin/gcx environment/gcx
-mise run setup:preflight
-```
-
-Either way, the Docker image will use your local binary instead of downloading
+When set, the Docker image will use your local binary instead of downloading
 from GitHub. The `environment/gcx` file is gitignored and cleaned up after build.
 
-The binary must be a **Linux** executable matching the Docker image architecture.
-If you're on macOS, a native `go build` produces a binary that won't run inside
-the container. Build the binary for linux first:
+Use `GOARCH=amd64` if your Docker is running x86_64 images.
 
 ```bash
 cd ~/workspace/gcx && GOOS=linux GOARCH=arm64 mise run build
-LOCAL_GCX=~/path/to/gcx/bin/gcx-linux mise run setup:preflight
+LOCAL_GCX=/path/to/gcx/bin/gcx-linux mise run bench:job -- --model openai/gpt-5.4-nano
 ```
 
-Use `GOARCH=amd64` if your Docker is running x86_64 images.
 
 ## Running Your Own Models
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ If you're on macOS, a native `go build` produces a binary that won't run inside
 the container. Build the binary for linux first:
 
 ```bash
-cd ~/workspace/gcx && GOOS=linux GOARCH=arm64 go build -o bin/gcx-linux ./cmd/gcx
+cd ~/workspace/gcx && GOOS=linux GOARCH=arm64 mise run build
 LOCAL_GCX=~/path/to/gcx/bin/gcx-linux mise run setup:preflight
 ```
 

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -31,6 +31,9 @@ class GcxOpenCodeAgent(OpenCode):
         parts.append(instruction)
         return "\n".join(parts)
 
+    def get_version_command(self) -> str | None:
+        return ". ~/.nvm/nvm.sh; echo opencode $(opencode --version); echo $(gcx --version)"
+
     def _convert_events_to_trajectory(self, events: list[dict[str, Any]]) -> Trajectory | None:
         """Inject a synthetic step_finish when the agent was killed mid-step.
 

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -32,7 +32,7 @@ class GcxOpenCodeAgent(OpenCode):
         return "\n".join(parts)
 
     def get_version_command(self) -> str | None:
-        return ". ~/.nvm/nvm.sh; echo opencode $(opencode --version); echo $(gcx --version)"
+        return f"{super().get_version_command()}; echo $(gcx --version)"
 
     def _convert_events_to_trajectory(self, events: list[dict[str, Any]]) -> Trajectory | None:
         """Inject a synthetic step_finish when the agent was killed mid-step.

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -3,15 +3,8 @@ FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:76c7449e8bd509a860b61eb0
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Install gcx — either from a local binary or from the remote install script.
-#
-# The --mount=type=bind makes files from the Docker build context (the environment/
-# directory) available at /ctx inside this RUN step, without copying them into the
-# image. If environment/gcx exists and is executable, we use it directly.
-# Otherwise we fall back to the standard remote install.
-#
-# To use a local build: copy your gcx binary to environment/gcx before building,
-# or set LOCAL_GCX=/path/to/binary when running harbor_preflight.sh.
+# Install gcx — use a local binary if present, otherwise fetch from GitHub.
+# --mount=type=bind exposes the build context at /ctx without adding a layer.
 RUN --mount=type=bind,source=.,target=/ctx \
     if [ -x /ctx/gcx ]; then \
       echo "Installing gcx from local binary"; \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,7 +1,24 @@
 FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:76c7449e8bd509a860b61eb060599fd9b1750bcbafe28008f769d35db6109a3d
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
-    && curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+    && rm -rf /var/lib/apt/lists/*
+
+# Install gcx — either from a local binary or from the remote install script.
+#
+# The --mount=type=bind makes files from the Docker build context (the environment/
+# directory) available at /ctx inside this RUN step, without copying them into the
+# image. If environment/gcx exists and is executable, we use it directly.
+# Otherwise we fall back to the standard remote install.
+#
+# To use a local build: copy your gcx binary to environment/gcx before building,
+# or set LOCAL_GCX=/path/to/binary when running harbor_preflight.sh.
+RUN --mount=type=bind,source=.,target=/ctx \
+    if [ -x /ctx/gcx ]; then \
+      echo "Installing gcx from local binary"; \
+      cp /ctx/gcx /usr/local/bin/gcx; \
+    else \
+      curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh; \
+    fi
 
 RUN gcx agent skills install --all \
     && mkdir -p ~/.config/opencode/skills \

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@ min_version = "2024.1.0"
 
 [tools]
 python = "3.14"
-uv = "0.11"
+uv = "0.11.8"
 
 # -- Setup (dependencies for bench tasks) --
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@ min_version = "2024.1.0"
 
 [tools]
 python = "3.14"
-uv = "0.11.8"
+uv = "0.11"
 
 # -- Setup (dependencies for bench tasks) --
 

--- a/o11y_bench/run.py
+++ b/o11y_bench/run.py
@@ -264,6 +264,29 @@ def _sanitize_trial_result_payload(
     return changed
 
 
+def _extract_gcx_version(job_dir: Path) -> str | None:
+    """Read the gcx version from the first trial's agent_info, if present."""
+    for trial_dir in _iter_trial_dirs(job_dir):
+        result = _read_json_dict(trial_dir / "result.json")
+        if not isinstance(result, dict):
+            continue
+        version = (result.get("agent_info") or {}).get("version")
+        if isinstance(version, str):
+            for line in version.splitlines():
+                if line.startswith("gcx version"):
+                    return line
+    return None
+
+
+def _uses_gcx_agent(config_payload: dict[str, Any]) -> bool:
+    agents = config_payload.get("agents")
+    if not isinstance(agents, list):
+        return False
+    return any(
+        isinstance(a, dict) and "gcx_opencode_agent" in (a.get("import_path") or "") for a in agents
+    )
+
+
 def _sanitize_job_artifacts(job_dir: Path, tasks_dir: Path) -> None:
     config_path = job_dir / "config.json"
     if config_path.exists():
@@ -283,6 +306,12 @@ def _sanitize_job_artifacts(job_dir: Path, tasks_dir: Path) -> None:
                     if dataset.get("path") != portable_tasks_dir:
                         dataset["path"] = portable_tasks_dir
                         changed = True
+            # get gcx_version from one of the tasks and put it in the job-level config.json
+            if "gcx_version" not in config_payload and _uses_gcx_agent(config_payload):
+                gcx_version = _extract_gcx_version(job_dir)
+                if gcx_version:
+                    config_payload["gcx_version"] = gcx_version
+                    changed = True
             if changed:
                 _write_json_dict(config_path, config_payload)
 

--- a/scripts/harbor_preflight.sh
+++ b/scripts/harbor_preflight.sh
@@ -106,6 +106,18 @@ fi
 docker network inspect o11y-bench-shared >/dev/null 2>&1 || docker network create o11y-bench-shared >/dev/null
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# If LOCAL_GCX points to a binary, copy it into the build context so the
+# Dockerfile picks it up instead of downloading from GitHub.
+# Trap ensures cleanup even if the build fails, so a stale binary doesn't
+# silently get used on the next build.
+if [ -n "${LOCAL_GCX:-}" ]; then
+  echo "Using local gcx binary: $LOCAL_GCX"
+  cp "$LOCAL_GCX" "$ROOT/environment/gcx"
+  chmod +x "$ROOT/environment/gcx"
+  trap 'rm -f "$ROOT/environment/gcx"' EXIT INT TERM
+fi
+
 echo "Building shared Harbor main image: o11y-bench-main:latest"
 docker build -t o11y-bench-main:latest -f "$ROOT/environment/Dockerfile" "$ROOT/environment" >/dev/null
 echo "Building shared Harbor sidecar image: o11y-bench-o11y-stack:latest"

--- a/scripts/harbor_preflight.sh
+++ b/scripts/harbor_preflight.sh
@@ -116,6 +116,10 @@ if [ -n "${LOCAL_GCX:-}" ]; then
   cp "$LOCAL_GCX" "$ROOT/environment/gcx"
   chmod +x "$ROOT/environment/gcx"
   trap 'rm -f "$ROOT/environment/gcx"' EXIT INT TERM
+else
+  # make sure we remove leftover artifacts in the case where LOCAL_GCX is unset,
+  # to avoid accidentally using a stale local build.
+  rm -f "$ROOT/environment/gcx"
 fi
 
 echo "Building shared Harbor main image: o11y-bench-main:latest"

--- a/scripts/harbor_preflight.sh
+++ b/scripts/harbor_preflight.sh
@@ -119,7 +119,9 @@ if [ -n "${LOCAL_GCX:-}" ]; then
 fi
 
 echo "Building shared Harbor main image: o11y-bench-main:latest"
-docker build -t o11y-bench-main:latest -f "$ROOT/environment/Dockerfile" "$ROOT/environment" >/dev/null
+
+# dont cache to make sure the version of gcx is always up to date
+docker build --no-cache -t o11y-bench-main:latest -f "$ROOT/environment/Dockerfile" "$ROOT/environment" >/dev/null
 echo "Building shared Harbor sidecar image: o11y-bench-o11y-stack:latest"
 docker build -t o11y-bench-o11y-stack:latest -f "$ROOT/docker/Dockerfile" "$ROOT/docker" >/dev/null
 


### PR DESCRIPTION
I want to run the benchmarks against a locally-built gcx sometimes, instead of always using the latest gcx artifact from GH. This is useful for e.g. testing skills changes before release.


With this PR, I can set LOCAL_GCX to the path of a binary (built for linux) and it will use that in the agent harness instead of pulling gcx from github.

it also prints the gcx version into the result.json `agent_info.version` property, along with the version of openCode, so we can track skills performance over time