### PR TITLE
fix(ci): pin uv to verified release

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@ min_version = "2024.1.0"
 
 [tools]
 python = "3.14"
-uv = "latest"
+uv = "0.11.8"
 
 # -- Setup (dependencies for bench tasks) --
 


### PR DESCRIPTION
Pin `uv` in `mise.toml` to `0.11.8` instead of `latest`.

`uv@0.11.9` currently fails mise/aqua GitHub artifact attestation verification, which breaks CI before repo checks run. `0.11.8` still verifies successfully and keeps CI deterministic.