### PR TITLE
Remove default agent temperature

### DIFF
--- a/agents/agent_runner.py
+++ b/agents/agent_runner.py
@@ -9,7 +9,7 @@
 Connects to mcp-grafana via streamable-http, runs an agent loop using litellm
 (multi-provider: Anthropic, OpenAI, Google, etc.), and writes an ATIF trajectory.
 
-Config via env vars: MODEL, MCP_URL, REASONING_EFFORT, TEMPERATURE, provider API keys.
+Config via env vars: MODEL, MCP_URL, REASONING_EFFORT, optional TEMPERATURE, provider API keys.
 For OpenAI-compatible endpoints (local or hosted), use ``openai/<id>`` + ``OPENAI_API_BASE``
 (and ``OPENAI_API_KEY`` if required). See LiteLLM provider docs for other routes.
 Timeout is handled by Harbor's agent timeout in task.toml.
@@ -259,7 +259,7 @@ async def run_agent() -> None:
     stack_host = os.environ.get("STACK_HOST", "127.0.0.1")
     mcp_url = os.environ.get("MCP_URL", f"http://{stack_host}:8080/mcp")
     reasoning_effort = os.environ.get("REASONING_EFFORT", "off")
-    temperature = float(os.environ.get("TEMPERATURE", "0.0"))
+    temperature = os.environ.get("TEMPERATURE")
 
     statement = Path("/app/instruction.txt").read_text().strip()
 
@@ -340,8 +340,8 @@ async def run_agent() -> None:
                 }
                 if reasoning_effort != "off":
                     litellm_kwargs["reasoning_effort"] = reasoning_effort
-                elif "claude-opus-4-7" not in model:
-                    litellm_kwargs["temperature"] = temperature
+                if temperature:
+                    litellm_kwargs["temperature"] = float(temperature)
 
                 step = 0
                 while True:

--- a/agents/agent_runner.py
+++ b/agents/agent_runner.py
@@ -250,6 +250,28 @@ async def completion_with_retries(
     raise RuntimeError("completion retries exhausted")
 
 
+def build_litellm_kwargs(
+    model: str,
+    tools: list[dict[str, Any]],
+    reasoning_effort: str,
+    temperature: str | None,
+) -> dict[str, Any]:
+    litellm_kwargs: dict[str, Any] = {
+        "model": model,
+        "tools": tools,
+        "drop_params": True,
+        "cache_control_injection_points": [
+            {"location": "message", "role": "system"},
+        ],
+    }
+    if reasoning_effort != "off":
+        litellm_kwargs["reasoning_effort"] = reasoning_effort
+    elif temperature is not None and "claude-opus-4-7" not in model:
+        litellm_kwargs["temperature"] = float(temperature)
+
+    return litellm_kwargs
+
+
 async def run_agent() -> None:
     import litellm
     from mcp.client.session import ClientSession
@@ -330,18 +352,12 @@ async def run_agent() -> None:
                     {"role": "user", "content": task_prompt},
                 ]
 
-                litellm_kwargs: dict[str, Any] = {
-                    "model": model,
-                    "tools": tools,
-                    "drop_params": True,
-                    "cache_control_injection_points": [
-                        {"location": "message", "role": "system"},
-                    ],
-                }
-                if reasoning_effort != "off":
-                    litellm_kwargs["reasoning_effort"] = reasoning_effort
-                if temperature:
-                    litellm_kwargs["temperature"] = float(temperature)
+                litellm_kwargs = build_litellm_kwargs(
+                    model,
+                    tools,
+                    reasoning_effort,
+                    temperature,
+                )
 
                 step = 0
                 while True:

--- a/agents/o11y_agent.py
+++ b/agents/o11y_agent.py
@@ -63,7 +63,7 @@ class O11yBenchAgent(BaseAgent):
         logs_dir: Path,
         model_name: str | None = None,
         reasoning_effort: str = "off",
-        temperature: float = 0.0,
+        temperature: float | None = None,
         extra_env: dict[str, str] | None = None,
         **kwargs: Any,
     ):
@@ -115,7 +115,6 @@ class O11yBenchAgent(BaseAgent):
         env: dict[str, str] = {
             "MODEL": model,
             "REASONING_EFFORT": self.reasoning_effort,
-            "TEMPERATURE": str(self.temperature),
             "PATH": "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin",
             # uv may run the runner from a cache dir; keep uploads under /app importable.
             "PYTHONPATH": "/app",
@@ -137,6 +136,8 @@ class O11yBenchAgent(BaseAgent):
             env["GOOGLE_API_KEY"] = gemini_api_key
         if mcp_url:
             env["MCP_URL"] = mcp_url
+        if self.temperature is not None:
+            env["TEMPERATURE"] = str(self.temperature)
         env.update(self._extra_env)
 
         self.logger.info(f"Running agent runner with model={model}")

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -66,6 +66,31 @@ def test_o11y_trajectory_metadata_validates_against_harbor_model() -> None:
     assert parsed.final_metrics.extra["reasoning_effort"] == "off"
 
 
+def test_build_litellm_kwargs_omits_temperature_when_unset() -> None:
+    result = agent_runner.build_litellm_kwargs("openai/gpt-5.4-mini", [], "off", None)
+
+    assert "temperature" not in result
+
+
+def test_build_litellm_kwargs_parses_explicit_zero_temperature() -> None:
+    result = agent_runner.build_litellm_kwargs("openai/gpt-5.4-mini", [], "off", "0")
+
+    assert result["temperature"] == 0.0
+
+
+def test_build_litellm_kwargs_prefers_reasoning_effort_over_temperature() -> None:
+    result = agent_runner.build_litellm_kwargs("openai/gpt-5.4-mini", [], "medium", "0")
+
+    assert result["reasoning_effort"] == "medium"
+    assert "temperature" not in result
+
+
+def test_build_litellm_kwargs_omits_temperature_for_claude_opus_4_7() -> None:
+    result = agent_runner.build_litellm_kwargs("anthropic/claude-opus-4-7", [], "off", "0")
+
+    assert "temperature" not in result
+
+
 @pytest.mark.parametrize(
     ("error", "expected"),
     [

--- a/tests/test_o11y_agent.py
+++ b/tests/test_o11y_agent.py
@@ -100,6 +100,25 @@ async def test_run_passes_through_scenario_clock_env(
     assert env.exec_calls
     _, call_env = env.exec_calls[0]
     assert call_env["O11Y_SCENARIO_TIME_ISO"] == "2026-04-04T10:05:14Z"
+    assert "TEMPERATURE" not in call_env
+
+
+@pytest.mark.anyio
+async def test_run_passes_explicit_temperature_agent_kwarg(tmp_path: Path) -> None:
+    agent = O11yBenchAgent(
+        logs_dir=tmp_path,
+        model_name="anthropic/claude-opus-4-6",
+        temperature=0,
+    )
+    env: Any = MockEnvironment(MockExecResult(return_code=1))
+    context = AgentContext()
+
+    with pytest.raises(NonZeroAgentExitCodeError):
+        await agent.run("do the thing", env, context)
+
+    assert env.exec_calls
+    _, call_env = env.exec_calls[0]
+    assert call_env["TEMPERATURE"] == "0"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Why
Harbor 0.6.5 no longer sends a default temperature, so the custom o11y-bench agent should use provider defaults unless configured otherwise.

## What Changed
- Stop exporting `TEMPERATURE=0.0` by default.
- Only pass LiteLLM `temperature` when the agent receives an explicit temperature kwarg.
- Cover default and explicit temperature behavior in agent tests.

## Test Plan
- `uv run pytest tests/test_o11y_agent.py tests/test_agent_runner.py`
- `uv run ruff check agents/o11y_agent.py agents/agent_runner.py tests/test_o11y_agent.py`

Made with [Cursor](https://cursor.com)