### PR TITLE
Pass raw Harbor args through job runner

### DIFF
--- a/o11y_bench/cli.py
+++ b/o11y_bench/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 from pathlib import Path
 
 from reporting.report_paths import latest_job_dir, normalize_repo_path
@@ -100,11 +101,7 @@ def main() -> None:
     regrade_parser.add_argument("--job-name")
     regrade_parser.add_argument("--quiet", action="store_true")
 
-    args, extra_args = parser.parse_known_args()
-    if args.command == "job":
-        args.harbor_args = tuple(arg for arg in extra_args if arg != "--")
-    elif extra_args:
-        parser.error(f"unrecognized arguments: {' '.join(extra_args)}")
+    args = _parse_args(parser)
 
     match args.command:
         case "run":
@@ -117,6 +114,16 @@ def main() -> None:
             _cmd_finalize(args)
         case "regrade":
             _cmd_regrade(args)
+
+
+def _parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
+    raw_args = sys.argv[1:]
+    if raw_args[:1] != ["job"]:
+        return parser.parse_args(raw_args)
+
+    args, harbor_args = parser.parse_known_args(raw_args)
+    args.harbor_args = tuple(arg for arg in harbor_args if arg != "--")
+    return args
 
 
 def _cmd_run(args: argparse.Namespace) -> None:

--- a/o11y_bench/cli.py
+++ b/o11y_bench/cli.py
@@ -100,7 +100,11 @@ def main() -> None:
     regrade_parser.add_argument("--job-name")
     regrade_parser.add_argument("--quiet", action="store_true")
 
-    args = parser.parse_args()
+    args, extra_args = parser.parse_known_args()
+    if args.command == "job":
+        args.harbor_args = tuple(arg for arg in extra_args if arg != "--")
+    elif extra_args:
+        parser.error(f"unrecognized arguments: {' '.join(extra_args)}")
 
     match args.command:
         case "run":
@@ -182,6 +186,7 @@ def _cmd_job(args: argparse.Namespace) -> None:
         override_memory_mb=args.override_memory_mb,
         override_storage_mb=args.override_storage_mb,
         task_names=tuple(args.task_name),
+        harbor_args=tuple(getattr(args, "harbor_args", ())),
     )
 
     if not args.dry_run:

--- a/o11y_bench/config.py
+++ b/o11y_bench/config.py
@@ -81,6 +81,7 @@ class JobSpec:
     override_memory_mb: int | None = None
     override_storage_mb: int | None = None
     task_names: tuple[str, ...] = ()
+    harbor_args: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/o11y_bench/harbor.py
+++ b/o11y_bench/harbor.py
@@ -49,12 +49,15 @@ def build_command(spec: JobSpec, *, quiet: bool = False) -> list[str]:
         command.extend(["--override-memory-mb", str(spec.override_memory_mb)])
     if spec.override_storage_mb is not None:
         command.extend(["--override-storage-mb", str(spec.override_storage_mb)])
+    command.extend(spec.harbor_args)
     if quiet:
         command.append("--quiet")
     return command
 
 
-def build_resume_command(config_path: str, *, quiet: bool = False) -> list[str]:
+def build_resume_command(
+    config_path: str, *, quiet: bool = False, harbor_args: tuple[str, ...] = ()
+) -> list[str]:
     """Build a `harbor run` command that resumes an existing job from its saved config."""
     command = [
         "uv",
@@ -65,6 +68,7 @@ def build_resume_command(config_path: str, *, quiet: bool = False) -> list[str]:
         "--config",
         config_path,
     ]
+    command.extend(harbor_args)
     if quiet:
         command.append("--quiet")
     return command

--- a/o11y_bench/run.py
+++ b/o11y_bench/run.py
@@ -539,7 +539,11 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
     rerun_harbor_exit_code: int | None = None
     if needs_harbor:
         rerun_harbor_exit_code = run_harbor(
-            build_resume_command(str(job_dir / "config.json"), quiet=quiet),
+            build_resume_command(
+                str(job_dir / "config.json"),
+                quiet=quiet,
+                harbor_args=spec.harbor_args,
+            ),
             forward_signals=False,
         )
 

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -409,6 +409,19 @@ def test_main_passes_unknown_job_args_through_to_harbor(monkeypatch) -> None:
     assert execute_calls[0].harbor_args == ("--ak", "temperature=0")
 
 
+def test_main_rejects_unknown_args_before_job_subcommand(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["o11y_bench", "--quiet", "job", "--model", "openai/gpt-5.4-nano"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+
+    assert exc_info.value.code != 0
+
+
 def test_cmd_job_rejects_agent_and_agent_import_path_together() -> None:
     args = argparse.Namespace(
         model="openai/gpt-5.4-nano",

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -1,11 +1,16 @@
 import argparse
 import json
+import sys
 from contextlib import nullcontext
 from types import SimpleNamespace
 
 import pytest
 
 from o11y_bench import cli, config, harbor, run
+
+
+def _option_values(command: list[str], option: str) -> list[str]:
+    return [command[i + 1] for i, arg in enumerate(command[:-1]) if arg == option]
 
 
 def test_build_command_produces_valid_harbor_invocation() -> None:
@@ -17,6 +22,7 @@ def test_build_command_produces_valid_harbor_invocation() -> None:
         reasoning_effort="off",
         n_attempts=3,
         n_concurrent=8,
+        harbor_args=("--ak", "temperature=0"),
     )
     command = harbor.build_command(spec)
 
@@ -24,6 +30,7 @@ def test_build_command_produces_valid_harbor_invocation() -> None:
     assert "--yes" in command
     assert "openai/gpt-5.4-mini" in command
     assert "test-job" in command
+    assert "temperature=0" in _option_values(command, "--ak")
 
 
 def test_build_command_maps_task_filters_to_harbor_include_task_name() -> None:
@@ -75,6 +82,7 @@ def test_execute_job_resumes_from_saved_config(monkeypatch, tmp_path) -> None:
         reasoning_effort="off",
         n_attempts=3,
         n_concurrent=2,
+        harbor_args=("--ak", "temperature=0"),
     )
 
     monkeypatch.setattr(run, "compute_task_checksums", lambda tasks_dir: {})
@@ -99,17 +107,23 @@ def test_execute_job_resumes_from_saved_config(monkeypatch, tmp_path) -> None:
         lambda job_dir, tasks_dir, task_checksums: job_dir / "run_report.html",
     )
 
-    harbor_calls: list[list[str]] = []
-    monkeypatch.setattr(
-        run, "run_harbor", lambda command, **kwargs: harbor_calls.append(command) or 0
-    )
+    harbor_calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def fake_run_harbor(command: list[str], **kwargs: object) -> int:
+        harbor_calls.append((command, kwargs))
+        return 0
+
+    monkeypatch.setattr(run, "run_harbor", fake_run_harbor)
 
     result = run.execute_job(spec, quiet=True)
 
     assert result.harbor_exit_code == 0
-    assert harbor_calls == [
-        ["uv", "run", "harbor", "run", "--yes", "--config", str(job_dir / "config.json"), "--quiet"]
-    ]
+    assert len(harbor_calls) == 1
+    command, kwargs = harbor_calls[0]
+    assert str(job_dir / "config.json") in _option_values(command, "--config")
+    assert "temperature=0" in _option_values(command, "--ak")
+    assert "--quiet" in command
+    assert kwargs == {"forward_signals": False}
 
 
 def test_finalize_job_dir_sanitizes_artifact_paths(monkeypatch, tmp_path) -> None:
@@ -371,6 +385,28 @@ def test_cmd_job_auto_job_name_includes_custom_agent_import_path(monkeypatch) ->
 
     assert len(execute_calls) == 1
     assert execute_calls[0].job_name == "openai-gpt-5-4-nano-off-custom-agents-my-agent-myagent-k3"
+
+
+def test_main_passes_unknown_job_args_through_to_harbor(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["o11y_bench", "job", "--model", "openai/gpt-5.4-nano", "--ak", "temperature=0"],
+    )
+    monkeypatch.setattr(cli, "run_preflight", lambda *, quiet=False: None)
+
+    execute_calls: list[config.JobSpec] = []
+
+    def fake_execute_job(spec: config.JobSpec, *, dry_run: bool = False, quiet: bool = False):
+        execute_calls.append(spec)
+        return run.JobResult(status="dry_run", job_name=spec.job_name)
+
+    monkeypatch.setattr(cli, "execute_job", fake_execute_job)
+
+    cli.main()
+
+    assert len(execute_calls) == 1
+    assert execute_calls[0].harbor_args == ("--ak", "temperature=0")
 
 
 def test_cmd_job_rejects_agent_and_agent_import_path_together() -> None:


### PR DESCRIPTION
## Why
`bench:job` should not need bespoke wrapper flags for every Harbor option.

## What Changed
- Allow unknown `o11y_bench job` args to pass through to `harbor run`.
- Preserve raw Harbor args for both fresh and resume invocations.
- Add focused coverage for `--ak temperature=0` passthrough.

## Test Plan
- `uv run pytest tests/test_run_job.py`
- `uv run ruff check o11y_bench/cli.py o11y_bench/config.py o11y_bench/harbor.py o11y_bench/run.py tests/test_run_job.py`

Made with [Cursor](https://cursor.com)