### PR TITLE
Update tool call checks to also support matching on bash command phrases

### DIFF
--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:76c7449e8bd509a860b61eb0
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
 
-RUN gcx skills install --all \
+RUN gcx agent skills install --all \
     && mkdir -p ~/.config/opencode/skills \
     && ln -s ~/.agents/skills/* ~/.config/opencode/skills/
 

--- a/grading/checks.py
+++ b/grading/checks.py
@@ -11,10 +11,11 @@ from grading.helpers import (
     as_name_set,
     assistant_scope_note,
     assistant_text_blobs,
+    bash_command_matches,
     require_stack_url,
     response_cites_trace_id_prefix,
     tempo_tool_matches_name,
-    tool_call_id_to_name,
+    tool_call_id_to_tool_calls,
     trace_ids_from_tool_content,
 )
 from grading.models import (
@@ -73,20 +74,28 @@ def validate_tool_trace_id_grounding(
         {"additional_tool_names": params.additional_tool_names}
     )
 
-    call_id_to_name = tool_call_id_to_name(transcript)
+    tool_calls = tool_call_id_to_tool_calls(transcript)
+    bash_patterns = (
+        as_name_set(params.bash_command_contains) if params.bash_command_contains else None
+    )
+
     found_ids: set[str] = set()
     for msg in transcript.messages:
         if msg.role != "tool" or not msg.tool_results:
             continue
         for tool_result in msg.tool_results:
-            name = call_id_to_name.get(tool_result.tool_call_id, "")
-            if name not in extra_tool_names and not tempo_tool_matches_name(
-                name,
-                allowed_names if allowed_names else None,
-                params.tool_name_prefix,
+            tc = tool_calls.get(tool_result.tool_call_id)
+            name = tc.name if tc else ""
+            if (
+                name in extra_tool_names
+                or tempo_tool_matches_name(
+                    name,
+                    allowed_names if allowed_names else None,
+                    params.tool_name_prefix,
+                )
+                or (bash_patterns and tc and bash_command_matches(tc, bash_patterns))
             ):
-                continue
-            found_ids.update(trace_ids_from_tool_content(tool_result.content))
+                found_ids.update(trace_ids_from_tool_content(tool_result.content))
 
     if not found_ids:
         scope = (
@@ -96,6 +105,8 @@ def validate_tool_trace_id_grounding(
         )
         if extra_tool_names:
             scope += f" + {sorted(extra_tool_names)}"
+        if bash_patterns:
+            scope += f" + bash commands containing {sorted(bash_patterns)}"
         return 0.0, f"No hex trace IDs found in tool results{scope}."
 
     text_blobs = assistant_text_blobs(transcript, params.assistant_scope)

--- a/grading/helpers.py
+++ b/grading/helpers.py
@@ -53,11 +53,20 @@ def iter_tool_calls(transcript: Transcript) -> Iterator[ToolCall]:
             yield from msg.tool_calls
 
 
-def tool_call_id_to_name(transcript: Transcript) -> dict[str, str]:
-    out: dict[str, str] = {}
+def tool_call_id_to_tool_calls(transcript: Transcript) -> dict[str, ToolCall]:
+    out: dict[str, ToolCall] = {}
     for tool_call in iter_tool_calls(transcript):
-        out[tool_call.id] = tool_call.name
+        out[tool_call.id] = tool_call
     return out
+
+
+def bash_command_matches(tool_call: ToolCall, command_substrings: set[str]) -> bool:
+    if tool_call.name != "bash":
+        return False
+    command = tool_call.arguments.get("command", "")
+    if not isinstance(command, str):
+        return False
+    return any(substr in command for substr in command_substrings)
 
 
 def as_name_set(raw: str | list[str] | tuple[str, ...] | set[str] | None) -> set[str]:

--- a/grading/models.py
+++ b/grading/models.py
@@ -221,6 +221,8 @@ class ToolTraceIdGroundingParams(SpecModel):
     tool_name: str | list[str] | None = None
     tool_name_prefix: str = "tempo_"
     additional_tool_names: str | list[str] | None = None
+    # when agents use bash commands instead of tool calls, look for these strings in the command
+    bash_command_contains: str | list[str] | None = None
 
 
 class DashboardStateParams(DashboardSelector):

--- a/tasks-spec/investigation/payments-path-root-cause.yaml
+++ b/tasks-spec/investigation/payments-path-root-cause.yaml
@@ -19,6 +19,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response states 5xx request-log count for the dominant payments path accurately.

--- a/tasks-spec/investigation/slow-path-hotspot-correlation.yaml
+++ b/tasks-spec/investigation/slow-path-hotspot-correlation.yaml
@@ -21,6 +21,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response states Slow-request count for the dominant slow path accurately.

--- a/tasks-spec/tempo_query/find-slow-traces.yaml
+++ b/tasks-spec/tempo_query/find-slow-traces.yaml
@@ -12,6 +12,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response points to at least one concrete slow trace using a trace id, a named operation, or an explicit duration figure

--- a/tasks-spec/tempo_query/trace-error-analysis.yaml
+++ b/tasks-spec/tempo_query/trace-error-analysis.yaml
@@ -14,6 +14,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response correctly states that failed or errored traces are visible in Tempo over the requested window

--- a/tasks-spec/tempo_query/traceql-cache-refresh-hotspot.yaml
+++ b/tasks-spec/tempo_query/traceql-cache-refresh-hotspot.yaml
@@ -17,6 +17,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response identifies the `refresh auth cache` span (or an equivalent auth-cache refresh operation) inside user-service as the dominant hotspot on slow GET `/api/users` traces, rather than stopping at only a generic service-level summary

--- a/tasks-spec/tempo_query/traceql-cross-service-analysis.yaml
+++ b/tasks-spec/tempo_query/traceql-cross-service-analysis.yaml
@@ -17,6 +17,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
     additional_tool_names:
     - query_loki_logs
   name: Response cites a trace ID that appears in tool results

--- a/tasks-spec/tempo_query/traceql-discover-orders-error-attributes.yaml
+++ b/tasks-spec/tempo_query/traceql-discover-orders-error-attributes.yaml
@@ -17,6 +17,7 @@ checks:
     prefix_min_chars: 8
     assistant_scope: all
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response distinguishes the span where the error originates from upstream spans that only reflect the failed HTTP response

--- a/tasks-spec/tempo_query/traceql-error-chain-orders.yaml
+++ b/tasks-spec/tempo_query/traceql-error-chain-orders.yaml
@@ -15,6 +15,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response points to the first service or span in the chain where the error originates

--- a/tasks-spec/tempo_query/traceql-error-span-analysis.yaml
+++ b/tasks-spec/tempo_query/traceql-error-span-analysis.yaml
@@ -17,6 +17,7 @@ checks:
     prefix_min_chars: 8
     assistant_scope: all
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response discusses span-level evidence (span name, attribute, or status code - not only HTTP or service names)

--- a/tasks-spec/tempo_query/traceql-find-service-traces.yaml
+++ b/tasks-spec/tempo_query/traceql-find-service-traces.yaml
@@ -14,6 +14,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response includes at least one trace identifier and describes what appears inside that trace

--- a/tasks-spec/tempo_query/traceql-metrics-error-rate-by-service.yaml
+++ b/tasks-spec/tempo_query/traceql-metrics-error-rate-by-service.yaml
@@ -15,6 +15,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response explains why payment-service shows the highest erroring-span rate for POST /api/payments using span or metric evidence from the transcript

--- a/tasks-spec/tempo_query/traceql-structural-query.yaml
+++ b/tasks-spec/tempo_query/traceql-structural-query.yaml
@@ -16,6 +16,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response states downstream call durations or latencies taken from trace spans

--- a/tasks-spec/tempo_query/traceql-tail-latency-bottleneck.yaml
+++ b/tasks-spec/tempo_query/traceql-tail-latency-bottleneck.yaml
@@ -15,6 +15,7 @@ checks:
   params:
     prefix_min_chars: 8
     mode: tool_trace_id
+    bash_command_contains: "gcx traces"
   name: Response cites a trace ID that appears in Tempo tool results
 rubric:
 - criterion: The final response identifies the main downstream bottleneck from the cited slow trace rather than stopping at only top-level slowness.

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -104,6 +104,36 @@ def test_fetch_tempo_attribute_values_normalizes_v2_response_objects() -> None:
     assert values == ["api-gateway", "order-service"]
 
 
+def _bash_grounded_trace_response() -> Transcript:
+    return Transcript(
+        messages=[
+            Message(
+                role="assistant",
+                tool_calls=[
+                    ToolCall(
+                        id="bash-1",
+                        name="bash",
+                        arguments={"command": "gcx traces query -d tempo '{ duration > 1s }'"},
+                    )
+                ],
+            ),
+            Message(
+                role="tool",
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="bash-1",
+                        content='{"traces":[{"traceID":"2f0d253c538f68595d959a8a39d7a6a0"}]}',
+                    )
+                ],
+            ),
+            Message(
+                role="assistant",
+                content="A representative slow trace is 2f0d253c538f6859.",
+            ),
+        ]
+    )
+
+
 def test_run_checks_dispatches_trace_grounding() -> None:
     scores, explanations = run_checks(
         [
@@ -122,6 +152,53 @@ def test_run_checks_dispatches_trace_grounding() -> None:
 
     assert scores["trace grounding"] == 1.0
     assert "grounded in tool results" in explanations["trace grounding"]
+
+
+def test_trace_grounding_bash_command_contains() -> None:
+    scores, explanations = run_checks(
+        [
+            CheckItem.model_validate(
+                {
+                    "name": "trace grounding",
+                    "weight": 1.0,
+                    "type": "grounding",
+                    "params": {
+                        "mode": "tool_trace_id",
+                        "prefix_min_chars": 8,
+                        "bash_command_contains": "gcx traces",
+                    },
+                }
+            )
+        ],
+        _bash_grounded_trace_response(),
+        VerifierContext(tempo_url="http://tempo"),
+    )
+
+    assert scores["trace grounding"] == 1.0
+    assert "grounded in tool results" in explanations["trace grounding"]
+
+
+def test_trace_grounding_bash_command_no_match() -> None:
+    scores, _explanations = run_checks(
+        [
+            CheckItem.model_validate(
+                {
+                    "name": "trace grounding",
+                    "weight": 1.0,
+                    "type": "grounding",
+                    "params": {
+                        "mode": "tool_trace_id",
+                        "prefix_min_chars": 8,
+                        "bash_command_contains": "some other bash command",
+                    },
+                }
+            )
+        ],
+        _bash_grounded_trace_response(),
+        VerifierContext(tempo_url="http://tempo"),
+    )
+
+    assert scores["trace grounding"] == 0.0
 
 
 def test_state_datasource_detail_requires_configured_detail() -> None:


### PR DESCRIPTION
Currently, o11y-bench tasks that ask for a trace-related tool calls fail using the gcx harness, because that agent only calls the `bash` tool, with a command like `gcx traces ...` - something like this:

```json
{
  "tool_call_id": "toolu_01Py5sBErJtcNYSHUGxqifgB",
  "function_name": "bash",
  "arguments": {
    "command": "gcx traces get -d tempo 12a7b56f30b6f52291ac23b53d31b406 --llm 2>/dev/null",
    "description": "Get worst GET /api/cart trace (12.7s) with LLM output"
  }
}
```
This means these tasks get judged as failures, even though they show the right data and come to the correct conclusion. Here's an example of one of these runs:

[original run_report.html](https://github.com/user-attachments/files/27598930/run_report.html)


This PR changes the `ToolTraceIdGroundingParams` check, so that is also supports setting a bash command substring. If the tool call is `bash` and the command contains `bash_command_contains`, it will pass the check.

All checks in o11y-bench that use mode `tool_trace_id` have been updated to also have a `bash_command_contains` property to match on a `gcx traces` command.

Here's an updated analysis of the same run, using the same agent artifacts: [updated run_report.html](https://github.com/user-attachments/files/27599217/run_report.html)

You'll see that the heavily-weighted assertion `Response cites a trace ID that appears in Tempo tool results`  now correctly passes.


---

This should not affect the behaviour of the default agent, so it should not have an impact on the public o11y-bench test scenarios (i.e. we're not changing the standard benchmark here)


---

How to review:

1st commit: housekeeping - use updated gcx skills command
2nd commit: edit the check model to support bash command strings
3rd commit: edit all tests using that tool_call check to have an equivalent gcx bash command defined