### PR TITLE
Make trace ID grounding checks tool-agnostic

### DIFF
--- a/grading/checks.py
+++ b/grading/checks.py
@@ -7,14 +7,10 @@ from grading.env_context import (
     resolve_grafana_datasource,
 )
 from grading.helpers import (
-    additional_trace_id_tool_names,
-    as_name_set,
     assistant_scope_note,
     assistant_text_blobs,
     require_stack_url,
     response_cites_trace_id_prefix,
-    tempo_tool_matches_name,
-    tool_call_id_to_name,
     trace_ids_from_tool_content,
 )
 from grading.models import (
@@ -23,7 +19,7 @@ from grading.models import (
     DatasourceDetailStateParams,
     DatasourceInventoryStateParams,
     TempoTraceServiceInventoryStateParams,
-    ToolTraceIdGroundingParams,
+    TraceIdGroundingParams,
     Transcript,
 )
 
@@ -50,8 +46,8 @@ def run_check(
     ctx: VerifierContext | None,
 ) -> tuple[float, str]:
     match check.params:
-        case ToolTraceIdGroundingParams():
-            return validate_tool_trace_id_grounding(check.params, transcript)
+        case TraceIdGroundingParams():
+            return validate_trace_id_grounding(check.params, transcript)
         case DashboardStateParams():
             return validate_dashboard_state(check.params, transcript, ctx)
         case DatasourceInventoryStateParams():
@@ -64,39 +60,19 @@ def run_check(
             return 0.0, f"Unsupported check params mode {check.params.mode!r}."
 
 
-def validate_tool_trace_id_grounding(
-    params: ToolTraceIdGroundingParams,
+def validate_trace_id_grounding(
+    params: TraceIdGroundingParams,
     transcript: Transcript,
 ) -> tuple[float, str]:
-    allowed_names = as_name_set(params.tool_name) if params.tool_name else None
-    extra_tool_names = additional_trace_id_tool_names(
-        {"additional_tool_names": params.additional_tool_names}
-    )
-
-    call_id_to_name = tool_call_id_to_name(transcript)
     found_ids: set[str] = set()
     for msg in transcript.messages:
         if msg.role != "tool" or not msg.tool_results:
             continue
         for tool_result in msg.tool_results:
-            name = call_id_to_name.get(tool_result.tool_call_id, "")
-            if name not in extra_tool_names and not tempo_tool_matches_name(
-                name,
-                allowed_names if allowed_names else None,
-                params.tool_name_prefix,
-            ):
-                continue
             found_ids.update(trace_ids_from_tool_content(tool_result.content))
 
     if not found_ids:
-        scope = (
-            f" ({sorted(allowed_names)})"
-            if allowed_names
-            else f" (prefix {params.tool_name_prefix!r})"
-        )
-        if extra_tool_names:
-            scope += f" + {sorted(extra_tool_names)}"
-        return 0.0, f"No hex trace IDs found in tool results{scope}."
+        return 0.0, "No hex trace IDs found in any tool results."
 
     text_blobs = assistant_text_blobs(transcript, params.assistant_scope)
     if not text_blobs:

--- a/grading/helpers.py
+++ b/grading/helpers.py
@@ -5,9 +5,12 @@ from grading.env_context import synthetic_eval_time_unix
 from grading.models import Transcript
 
 _TRACE_ID_HEX_32 = re.compile(r"(?<![0-9a-fA-F])([0-9a-fA-F]{32})(?![0-9a-fA-F])")
-# Tempo search JSON often omits a leading zero (31 hex chars); get-trace uses 32.
+# _TRACE_ID_HEX_32 catches most trace IDs, but only matches exactly 32 hex chars.
+# Tempo search JSON sometimes omits a leading zero (31 chars), so this pattern
+# looks for known key names to pick those up too, but only in the JSON format we
+# know that trace commands use.
 _TRACE_ID_JSON = re.compile(
-    r'"(?:traceID|traceId)"\s*:\s*"([0-9a-fA-F]{31,32})"',
+    r'"trace[_]?id"\s*:\s*"([0-9a-fA-F]{31,32})"',
     re.IGNORECASE,
 )
 

--- a/grading/helpers.py
+++ b/grading/helpers.py
@@ -1,9 +1,8 @@
 import re
-from collections.abc import Iterator
 from typing import Any
 
 from grading.env_context import synthetic_eval_time_unix
-from grading.models import ToolCall, Transcript
+from grading.models import Transcript
 
 _TRACE_ID_HEX_32 = re.compile(r"(?<![0-9a-fA-F])([0-9a-fA-F]{32})(?![0-9a-fA-F])")
 # Tempo search JSON often omits a leading zero (31 hex chars); get-trace uses 32.
@@ -47,27 +46,6 @@ def assistant_text_blobs(transcript: Transcript, assistant_scope: str) -> list[s
     return blobs
 
 
-def iter_tool_calls(transcript: Transcript) -> Iterator[ToolCall]:
-    for msg in transcript.messages:
-        if msg.role == "assistant" and msg.tool_calls:
-            yield from msg.tool_calls
-
-
-def tool_call_id_to_name(transcript: Transcript) -> dict[str, str]:
-    out: dict[str, str] = {}
-    for tool_call in iter_tool_calls(transcript):
-        out[tool_call.id] = tool_call.name
-    return out
-
-
-def as_name_set(raw: str | list[str] | tuple[str, ...] | set[str] | None) -> set[str]:
-    if raw is None:
-        return set()
-    if isinstance(raw, str):
-        return {raw}
-    return {str(value) for value in raw}
-
-
 def require_stack_url(url: str, env_name: str) -> str | None:
     if url:
         return None
@@ -109,22 +87,12 @@ def response_cites_trace_id_prefix(
                 continue
             if not re.fullmatch(r"[0-9a-f]+", trace_id):
                 continue
+            # if the shortest prefix isn't in the text, no longer prefix can be
+            # either. A bit of a fast-fail.
+            if trace_id[:prefix_min_chars] not in haystack:
+                continue
             for prefix_len in range(len(trace_id), prefix_min_chars - 1, -1):
                 prefix = trace_id[:prefix_len]
                 if prefix in haystack:
                     return True, prefix
     return False, None
-
-
-def tempo_tool_matches_name(
-    tool_name: str,
-    allowed_names: set[str] | None,
-    name_prefix: str,
-) -> bool:
-    if allowed_names is not None:
-        return tool_name in allowed_names
-    return tool_name.startswith(name_prefix)
-
-
-def additional_trace_id_tool_names(params: dict[str, Any]) -> set[str]:
-    return as_name_set(params.get("additional_tool_names"))

--- a/grading/models.py
+++ b/grading/models.py
@@ -214,13 +214,10 @@ class DashboardItemExpectation(SpecModel):
         raise ValueError("Dashboard item expectations must include at least one constraint.")
 
 
-class ToolTraceIdGroundingParams(SpecModel):
-    mode: Literal["tool_trace_id"]
+class TraceIdGroundingParams(SpecModel):
+    mode: Literal["trace_id"]
     prefix_min_chars: int = 8
     assistant_scope: Literal["final", "all"] = "final"
-    tool_name: str | list[str] | None = None
-    tool_name_prefix: str = "tempo_"
-    additional_tool_names: str | list[str] | None = None
 
 
 class DashboardStateParams(DashboardSelector):
@@ -285,7 +282,7 @@ class TempoTraceServiceInventoryStateParams(SpecModel):
 
 
 type CheckParams = Annotated[
-    ToolTraceIdGroundingParams
+    TraceIdGroundingParams
     | DashboardStateParams
     | DatasourceInventoryStateParams
     | DatasourceDetailStateParams
@@ -454,7 +451,7 @@ def collapse_whitespace(text: str) -> str:
 
 def check_type_for_params(params: CheckParams) -> Literal["grounding", "state"]:
     match params:
-        case ToolTraceIdGroundingParams():
+        case TraceIdGroundingParams():
             return "grounding"
         case (
             DashboardStateParams()

--- a/o11y_bench/regrade_stack.py
+++ b/o11y_bench/regrade_stack.py
@@ -14,7 +14,7 @@ from grading.models import (
     DatasourceInventoryStateParams,
     Problem,
     TempoTraceServiceInventoryStateParams,
-    ToolTraceIdGroundingParams,
+    TraceIdGroundingParams,
 )
 
 
@@ -26,7 +26,7 @@ def problem_requires_live_stack(problem: Problem) -> bool:
 
 def check_requires_live_stack(params: object) -> bool:
     match params:
-        case ToolTraceIdGroundingParams():
+        case TraceIdGroundingParams():
             return False
         case (
             DashboardStateParams()

--- a/tasks-spec/investigation/payments-path-root-cause.yaml
+++ b/tasks-spec/investigation/payments-path-root-cause.yaml
@@ -18,8 +18,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response states 5xx request-log count for the dominant payments path accurately.
   weight: 30

--- a/tasks-spec/investigation/slow-path-hotspot-correlation.yaml
+++ b/tasks-spec/investigation/slow-path-hotspot-correlation.yaml
@@ -20,8 +20,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response states Slow-request count for the dominant slow path accurately.
   weight: 30

--- a/tasks-spec/tempo_query/find-slow-traces.yaml
+++ b/tasks-spec/tempo_query/find-slow-traces.yaml
@@ -11,8 +11,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response points to at least one concrete slow trace using a trace id, a named operation, or an explicit duration figure
   weight: 5.0

--- a/tasks-spec/tempo_query/trace-error-analysis.yaml
+++ b/tasks-spec/tempo_query/trace-error-analysis.yaml
@@ -13,8 +13,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response correctly states that failed or errored traces are visible in Tempo over the requested window
   weight: 25

--- a/tasks-spec/tempo_query/traceql-cache-refresh-hotspot.yaml
+++ b/tasks-spec/tempo_query/traceql-cache-refresh-hotspot.yaml
@@ -16,8 +16,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response identifies the `refresh auth cache` span (or an equivalent auth-cache refresh operation) inside user-service as the dominant hotspot on slow GET `/api/users` traces, rather than stopping at only a generic service-level summary
   weight: 25

--- a/tasks-spec/tempo_query/traceql-cross-service-analysis.yaml
+++ b/tasks-spec/tempo_query/traceql-cross-service-analysis.yaml
@@ -16,9 +16,7 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-    additional_tool_names:
-    - query_loki_logs
+    mode: trace_id
   name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response identifies the single largest latency contributor using span durations or timings from trace data

--- a/tasks-spec/tempo_query/traceql-discover-orders-error-attributes.yaml
+++ b/tasks-spec/tempo_query/traceql-discover-orders-error-attributes.yaml
@@ -16,8 +16,8 @@ checks:
   params:
     prefix_min_chars: 8
     assistant_scope: all
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response distinguishes the span where the error originates from upstream spans that only reflect the failed HTTP response
   weight: 10.0

--- a/tasks-spec/tempo_query/traceql-error-chain-orders.yaml
+++ b/tasks-spec/tempo_query/traceql-error-chain-orders.yaml
@@ -14,8 +14,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response points to the first service or span in the chain where the error originates
   weight: 5.0

--- a/tasks-spec/tempo_query/traceql-error-span-analysis.yaml
+++ b/tasks-spec/tempo_query/traceql-error-span-analysis.yaml
@@ -16,8 +16,8 @@ checks:
   params:
     prefix_min_chars: 8
     assistant_scope: all
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response discusses span-level evidence (span name, attribute, or status code - not only HTTP or service names)
   weight: 25.0

--- a/tasks-spec/tempo_query/traceql-find-service-traces.yaml
+++ b/tasks-spec/tempo_query/traceql-find-service-traces.yaml
@@ -13,8 +13,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response includes at least one trace identifier and describes what appears inside that trace
   weight: 10.0

--- a/tasks-spec/tempo_query/traceql-metrics-error-rate-by-service.yaml
+++ b/tasks-spec/tempo_query/traceql-metrics-error-rate-by-service.yaml
@@ -14,8 +14,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response explains why payment-service shows the highest erroring-span rate for POST /api/payments using span or metric evidence from the transcript
   weight: 10.0

--- a/tasks-spec/tempo_query/traceql-structural-query.yaml
+++ b/tasks-spec/tempo_query/traceql-structural-query.yaml
@@ -15,8 +15,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response states downstream call durations or latencies taken from trace spans
   weight: 15.0

--- a/tasks-spec/tempo_query/traceql-tail-latency-bottleneck.yaml
+++ b/tasks-spec/tempo_query/traceql-tail-latency-bottleneck.yaml
@@ -14,8 +14,8 @@ checks:
   type: grounding
   params:
     prefix_min_chars: 8
-    mode: tool_trace_id
-  name: Response cites a trace ID that appears in Tempo tool results
+    mode: trace_id
+  name: Response cites a trace ID that appears in tool results
 rubric:
 - criterion: The final response identifies the main downstream bottleneck from the cited slow trace rather than stopping at only top-level slowness.
   weight: 15

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -112,12 +112,56 @@ def test_run_checks_dispatches_trace_grounding() -> None:
                     "name": "trace grounding",
                     "weight": 1.0,
                     "type": "grounding",
-                    "params": {"mode": "tool_trace_id", "prefix_min_chars": 8},
+                    "params": {"mode": "trace_id", "prefix_min_chars": 8},
                 }
             )
         ],
         _tool_grounded_trace_response(),
         VerifierContext(tempo_url="http://tempo"),
+    )
+
+    assert scores["trace grounding"] == 1.0
+    assert "grounded in tool results" in explanations["trace grounding"]
+
+
+def test_run_checks_trace_grounding_accepts_non_tempo_tool_source() -> None:
+    transcript = Transcript(
+        messages=[
+            Message(
+                role="assistant",
+                tool_calls=[
+                    ToolCall(id="loki-1", name="query_loki_logs", arguments={"query": "ignored"})
+                ],
+            ),
+            Message(
+                role="tool",
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="loki-1",
+                        content='{"traceID":"2f0d253c538f68595d959a8a39d7a6a0","level":"error"}',
+                    )
+                ],
+            ),
+            Message(
+                role="assistant",
+                content="A representative trace from the logs is 2f0d253c538f6859.",
+            ),
+        ]
+    )
+
+    scores, explanations = run_checks(
+        [
+            CheckItem.model_validate(
+                {
+                    "name": "trace grounding",
+                    "weight": 1.0,
+                    "type": "grounding",
+                    "params": {"mode": "trace_id", "prefix_min_chars": 8},
+                }
+            )
+        ],
+        transcript,
+        VerifierContext(),
     )
 
     assert scores["trace grounding"] == 1.0

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -168,6 +168,50 @@ def test_run_checks_trace_grounding_accepts_non_tempo_tool_source() -> None:
     assert "grounded in tool results" in explanations["trace grounding"]
 
 
+def test_run_checks_trace_grounding_matches_snake_case_trace_id_key() -> None:
+    transcript = Transcript(
+        messages=[
+            Message(
+                role="assistant",
+                tool_calls=[
+                    ToolCall(id="loki-1", name="query_loki_logs", arguments={"query": "ignored"})
+                ],
+            ),
+            Message(
+                role="tool",
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="loki-1",
+                        content='{"level":"error","trace_id":"2f0d253c538f68595d959a8a39d7a6a0","message":"upstream service error"}',
+                    )
+                ],
+            ),
+            Message(
+                role="assistant",
+                content="The error trace is 2f0d253c538f6859.",
+            ),
+        ]
+    )
+
+    scores, explanations = run_checks(
+        [
+            CheckItem.model_validate(
+                {
+                    "name": "trace grounding",
+                    "weight": 1.0,
+                    "type": "grounding",
+                    "params": {"mode": "trace_id", "prefix_min_chars": 8},
+                }
+            )
+        ],
+        transcript,
+        VerifierContext(),
+    )
+
+    assert scores["trace grounding"] == 1.0
+    assert "grounded in tool results" in explanations["trace grounding"]
+
+
 def test_state_datasource_detail_requires_configured_detail() -> None:
     with patch(
         "grading.checks.fetch_grafana_datasources_checked",

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -182,7 +182,11 @@ def test_run_checks_trace_grounding_matches_snake_case_trace_id_key() -> None:
                 tool_results=[
                     ToolResult(
                         tool_call_id="loki-1",
-                        content='{"level":"error","trace_id":"2f0d253c538f68595d959a8a39d7a6a0","message":"upstream service error"}',
+                        content=(
+                            '{"level":"error",'
+                            '"trace_id":"2f0d253c538f68595d959a8a39d7a6a0",'
+                            '"message":"upstream service error"}'
+                        ),
                     )
                 ],
             ),


### PR DESCRIPTION
An iteration on https://github.com/grafana/o11y-bench/pull/29. Instead of adding extra allowances for gcx calls with `bash`, this PR gets rid of the tool call name filtering, and checks all tool call outputs (bash commands also count as tool calls) for the trace IDs. The idea is to be more tool agnostic.

This trace-related grounding check previously filtered tool results by name (defaulting to `tempo_` prefix), with per-task `additional_tool_names` overrides when trace IDs came from non-Tempo tools like Loki. Now scans all tool results, removing that configuration completely. 

This puts more reliance on there being no "false positives" - nothing in the tool call responses that look like trace IDs, but aren't. Is that a reasonable tradeoff? It matches on two things:

- 32-char trace ID strings matching `_TRACE_ID_HEX_32 = re.compile(r"(?<![0-9a-fA-F])([0-9a-fA-F]{32})(?![0-9a-fA-F])")`
- 31 or 32 char trace ID strings matching this, with a required json key firs:
```py
_TRACE_ID_JSON = re.compile(
    r'"trace[_]?id"\s*:\s*"([0-9a-fA-F]{31,32})"',
    re.IGNORECASE,
)
```

This PR changes:

- Rename `ToolTraceIdGroundingParams` → `TraceIdGroundingParams`, mode `tool_trace_id` → `trace_id`
- Rename `validate_tool_trace_id_grounding` → `validate_trace_id_grounding`
- Remove `tool_name`, `tool_name_prefix`, and `additional_tool_names` params from the model
- Remove helper functions that only existed to support tool-name filtering: `iter_tool_calls`, `tool_call_id_to_name`, `as_name_set`, `tempo_tool_matches_name`, `additional_trace_id_tool_names`
- Add early-exit optimisation in `response_cites_trace_id_prefix` for non-matching trace IDs
- Update all 13 task specs
- Add a test for non-Tempo tool sources
- update `_TRACE_ID_JSON` so keys with underscore like `trace_id` are also matched




Here are some o11y-bench task runs using this update:
- [run of gcx agent against one of the trace tasks - run_report.html](https://github.com/user-attachments/files/27604033/run_report.html)
- [run of default agent against one of the trace tasks - run_report.html](https://github.com/user-attachments/files/27604050/run_report.html) (the failure looks legit, and unrelated to this change)
