### PR TITLE
Add existing system prompt to gcx agent

### DIFF
--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -23,6 +23,8 @@ class GcxOpenCodeAgent(OpenCode):
         self.mcp_servers = []
 
     def render_instruction(self, instruction: str) -> str:
+        """Inject the same system prompt as used in the o11y bench agent
+        """
         scenario_time = os.environ.get("O11Y_SCENARIO_TIME_ISO", "").strip()
         parts = [SYSTEM_PROMPT, ""]
         if scenario_time:

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -7,6 +7,7 @@ benchmarking gcx-only interaction. Clearing mcp_servers ensures the agent can
 only reach Grafana through gcx.
 """
 
+import os
 from typing import Any
 
 from harbor.agents.installed.opencode import OpenCode
@@ -17,6 +18,20 @@ class GcxOpenCodeAgent(OpenCode):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.mcp_servers = []
+
+    def render_instruction(self, instruction: str) -> str:
+        scenario_time = os.environ.get("O11Y_SCENARIO_TIME_ISO", "").strip()
+        if scenario_time:
+            return (
+                f"<context>\n"
+                f"Current time: {scenario_time}\n"
+                f"</context>\n\n"
+                f"Treat the Current time above as now. "
+                f"For time-bounded Prometheus, Loki, and Tempo queries, "
+                f"derive explicit time bounds from that time instead of relative now.\n\n"
+                f"{instruction}"
+            )
+        return instruction
 
     def _convert_events_to_trajectory(self, events: list[dict[str, Any]]) -> Trajectory | None:
         """Inject a synthetic step_finish when the agent was killed mid-step.

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -8,10 +8,13 @@ only reach Grafana through gcx.
 """
 
 import os
+from pathlib import Path
 from typing import Any
 
 from harbor.agents.installed.opencode import OpenCode
 from harbor.models.trajectories import Trajectory
+
+SYSTEM_PROMPT = Path(__file__).parent.joinpath("system_prompt.txt").read_text().strip()
 
 
 class GcxOpenCodeAgent(OpenCode):
@@ -21,17 +24,11 @@ class GcxOpenCodeAgent(OpenCode):
 
     def render_instruction(self, instruction: str) -> str:
         scenario_time = os.environ.get("O11Y_SCENARIO_TIME_ISO", "").strip()
+        parts = [SYSTEM_PROMPT, ""]
         if scenario_time:
-            return (
-                f"<context>\n"
-                f"Current time: {scenario_time}\n"
-                f"</context>\n\n"
-                f"Treat the Current time above as now. "
-                f"For time-bounded Prometheus, Loki, and Tempo queries, "
-                f"derive explicit time bounds from that time instead of relative now.\n\n"
-                f"{instruction}"
-            )
-        return instruction
+            parts.append(f"<context>\nCurrent time: {scenario_time}\n</context>\n")
+        parts.append(instruction)
+        return "\n".join(parts)
 
     def _convert_events_to_trajectory(self, events: list[dict[str, Any]]) -> Trajectory | None:
         """Inject a synthetic step_finish when the agent was killed mid-step.

--- a/agents/gcx_opencode_agent.py
+++ b/agents/gcx_opencode_agent.py
@@ -23,8 +23,7 @@ class GcxOpenCodeAgent(OpenCode):
         self.mcp_servers = []
 
     def render_instruction(self, instruction: str) -> str:
-        """Inject the same system prompt as used in the o11y bench agent
-        """
+        """Inject the same system prompt as used in the o11y bench agent"""
         scenario_time = os.environ.get("O11Y_SCENARIO_TIME_ISO", "").strip()
         parts = [SYSTEM_PROMPT, ""]
         if scenario_time:

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -3,7 +3,7 @@ FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim@sha256:76c7449e8bd509a860b61eb0
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
     && curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
 
-RUN gcx skills install --all \
+RUN gcx agent skills install --all \
     && mkdir -p ~/.config/opencode/skills \
     && ln -s ~/.agents/skills/* ~/.config/opencode/skills/
 


### PR DESCRIPTION
The o11y-bench harness uses a system prompt defined in https://github.com/grafana/o11y-bench/blob/main/agents/system_prompt.txt, but we currently dont use it in the gcx agent (it inherits whatever the opencode system prompt is). 

This PR changes the gcx agent so it also receives the same system prompt, to make comparisons more equal. One notable change now is that the test runs are aware of what the "current time" should be, for querying data