### PR TITLE
grading: default tool_trace_id check to scan all tool results

### DIFF
--- a/grading/checks.py
+++ b/grading/checks.py
@@ -89,11 +89,12 @@ def validate_tool_trace_id_grounding(
             found_ids.update(trace_ids_from_tool_content(tool_result.content))
 
     if not found_ids:
-        scope = (
-            f" ({sorted(allowed_names)})"
-            if allowed_names
-            else f" (prefix {params.tool_name_prefix!r})"
-        )
+        if allowed_names:
+            scope = f" ({sorted(allowed_names)})"
+        elif params.tool_name_prefix:
+            scope = f" (prefix {params.tool_name_prefix!r})"
+        else:
+            scope = ""
         if extra_tool_names:
             scope += f" + {sorted(extra_tool_names)}"
         return 0.0, f"No hex trace IDs found in tool results{scope}."

--- a/grading/helpers.py
+++ b/grading/helpers.py
@@ -123,6 +123,8 @@ def tempo_tool_matches_name(
 ) -> bool:
     if allowed_names is not None:
         return tool_name in allowed_names
+    if name_prefix == "":
+        return True
     return tool_name.startswith(name_prefix)
 
 

--- a/grading/models.py
+++ b/grading/models.py
@@ -219,7 +219,8 @@ class ToolTraceIdGroundingParams(SpecModel):
     prefix_min_chars: int = 8
     assistant_scope: Literal["final", "all"] = "final"
     tool_name: str | list[str] | None = None
-    tool_name_prefix: str = "tempo_"
+    # Empty default = scan all tool results; set explicitly (e.g. "tempo_") to filter.
+    tool_name_prefix: str = ""
     additional_tool_names: str | list[str] | None = None
 
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -124,6 +124,80 @@ def test_run_checks_dispatches_trace_grounding() -> None:
     assert "grounded in tool results" in explanations["trace grounding"]
 
 
+def _bash_grounded_trace_response() -> Transcript:
+    return Transcript(
+        messages=[
+            Message(
+                role="assistant",
+                tool_calls=[
+                    ToolCall(
+                        id="bash-1",
+                        name="bash",
+                        arguments={"command": "gcx traces query -d tempo '{}' -o json"},
+                    )
+                ],
+            ),
+            Message(
+                role="tool",
+                tool_results=[
+                    ToolResult(
+                        tool_call_id="bash-1",
+                        content='{"traces":[{"traceID":"2f0d253c538f68595d959a8a39d7a6a0"}]}',
+                    )
+                ],
+            ),
+            Message(
+                role="assistant",
+                content="A representative error trace is 2f0d253c538f6859 in order-service.",
+            ),
+        ]
+    )
+
+
+def test_trace_grounding_default_accepts_non_tempo_tool_names() -> None:
+    scores, explanations = run_checks(
+        [
+            CheckItem.model_validate(
+                {
+                    "name": "trace grounding",
+                    "weight": 1.0,
+                    "type": "grounding",
+                    "params": {"mode": "tool_trace_id", "prefix_min_chars": 8},
+                }
+            )
+        ],
+        _bash_grounded_trace_response(),
+        VerifierContext(tempo_url="http://tempo"),
+    )
+
+    assert scores["trace grounding"] == 1.0
+    assert "grounded in tool results" in explanations["trace grounding"]
+
+
+def test_trace_grounding_honours_explicit_tempo_prefix() -> None:
+    scores, explanations = run_checks(
+        [
+            CheckItem.model_validate(
+                {
+                    "name": "trace grounding",
+                    "weight": 1.0,
+                    "type": "grounding",
+                    "params": {
+                        "mode": "tool_trace_id",
+                        "prefix_min_chars": 8,
+                        "tool_name_prefix": "tempo_",
+                    },
+                }
+            )
+        ],
+        _bash_grounded_trace_response(),
+        VerifierContext(tempo_url="http://tempo"),
+    )
+
+    assert scores["trace grounding"] == 0.0
+    assert "prefix 'tempo_'" in explanations["trace grounding"]
+
+
 def test_state_datasource_detail_requires_configured_detail() -> None:
     with patch(
         "grading.checks.fetch_grafana_datasources_checked",


### PR DESCRIPTION
Default the `tool_trace_id` grounding check to scan all tool results instead of only those whose tool name starts with `tempo_`.


The previous default of `tool_name_prefix = "tempo_"` excluded every agent whose tool surface does not start with `tempo_`. 

I observed this on `trace-error-analysis` running a gcx-based agent: every attempt scored 0.20 (the `mode: tool_trace_id` check was the only failing one, weight 55/100). After this fix, mean reward on the same task went 0.20 → 0.83 with no agent change.

