### PR TITLE
feat: adding optional Grafana AI o11y export for experiment run tracking

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,41 @@
+# Required for grading.
+ANTHROPIC_API_KEY=
+
+# Required when running OpenAI models, for example `--model openai/gpt-5.4-nano`.
+OPENAI_API_KEY=
+
+# Optional provider keys. Fill in only the providers you use.
+GOOGLE_API_KEY=
+GEMINI_API_KEY=
+OPENROUTER_API_KEY=
+
+# Optional: OpenAI-compatible endpoint override.
+OPENAI_API_BASE=
+
+
+# Optional Sigil export configuration.
+# Enable export with:
+#   mise run sigil:setup
+#   mise run bench:job -- --sigil-experiment-export ...
+
+# Sigil has two auth planes:
+# 1. Ingest: transcripts and scores. o11y-bench passes these values to the SDK.
+# 2. Eval control plane: experiment create/update/finalize. The SDK reads SIGIL_EVAL_*.
+
+# Grafana Cloud ingest plane.
+# Copy the API URL from Grafana Cloud AI Observability configuration.
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_MODE=basic
+SIGIL_AUTH_TENANT_ID=<grafana-cloud-instance-or-tenant-id>
+SIGIL_AUTH_TOKEN=<grafana-cloud-access-policy-token>
+
+# Grafana Cloud eval control plane.
+# SIGIL_EVAL_ENDPOINT is your Grafana stack URL.
+SIGIL_EVAL_ENDPOINT=https://<stack>.grafana.net
+SIGIL_EVAL_PATH_PREFIX=/api/plugins/grafana-sigil-app/resources
+SIGIL_EVAL_AUTH_TOKEN=<grafana-service-account-token>
+
+# Optional: customize generated experiment links. Usually leave this unset; the
+# SDK builds the same URL from SIGIL_EVAL_ENDPOINT. Supported placeholders are
+# {base} and {run_id}.
+# SIGIL_EXPERIMENT_URL_TEMPLATE={base}/a/grafana-sigil-app/evaluation/experiments/{run_id}

--- a/README.md
+++ b/README.md
@@ -407,6 +407,47 @@ To submit:
 See the [submission repo README](https://huggingface.co/datasets/grafanalabs/o11y-bench-leaderboard) for
 the full submission structure, validation rules, and example layout.
 
+## Export Runs To Sigil (Optional)
+
+[Sigil](https://github.com/grafana/sigil) is Grafana's LLM observability tool. You can
+optionally export benchmark runs to Sigil as **experiments** to browse transcripts, track
+scores over time, and compare runs (e.g. two models or reasoning efforts) side by side.
+
+This is **off by default** and has no effect on the benchmark unless you opt in. Each
+completed trial becomes a Sigil generation (the agent transcript) plus a score (the
+verifier reward), all attributed to one experiment `run_id`.
+
+**1. Enable it** (one-time — installs the Sigil SDK into the venv):
+
+```bash
+mise run sigil:setup
+```
+
+This uses the local Sigil SDK checkout (expected as a sibling directory,
+`../sigil-sdk`). Once the SDK is published you can instead `uv pip install sigil-sdk`.
+
+**2. Run a job with live export** (point at your Sigil stack; defaults to `http://localhost:8080`):
+
+```bash
+mise run bench:job -- --model openai/gpt-5.4-nano --task-name query-cpu-metrics \
+  --sigil-experiment-export --sigil-api http://localhost:8080 --sigil-tenant fake
+```
+
+The experiment is created before Harbor starts and each trial streams to Sigil as it
+finishes; the run is finalized (succeeded/failed) when the job exits, and a link is printed.
+
+**Or export an already-completed job** after the fact:
+
+```bash
+uv run python -m o11y_bench sigil-export jobs/<job-name> --api http://localhost:8080 --tenant fake
+```
+
+Useful flags (both commands): `--sigil-run-id`/`--run-id` (stable id for idempotent
+re-exports), `--sigil-name`/`--name`, `--sigil-tag`/`--tag` (repeatable), and
+`--sigil-sdk-path`/`--sdk-path` (point at a local SDK checkout without installing it).
+Connection defaults also read `SIGIL_API_ENDPOINT`, `SIGIL_TENANT_ID`, and
+`SIGIL_SDK_PYTHON_PATH`.
+
 ## Common Local Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ You need all of the following installed locally:
 
 You also need model-provider API keys in your environment.
 
+For local development, copy `.env.sample` to `.env` and fill in the keys you use.
+`mise run ...` commands load `.env` automatically.
+
 Minimum environment variables:
 
 - `ANTHROPIC_API_KEY`
@@ -409,9 +412,9 @@ the full submission structure, validation rules, and example layout.
 
 ## Export Runs To Sigil (Optional)
 
-[Sigil](https://github.com/grafana/sigil) is Grafana's LLM observability tool. You can
-optionally export benchmark runs to Sigil as **experiments** to browse transcripts, track
-scores over time, and compare runs (e.g. two models or reasoning efforts) side by side.
+Sigil is Grafana's LLM observability tool. You can optionally export benchmark runs
+to Sigil as **experiments** to browse transcripts, track scores over time, and
+compare runs (e.g. two models or reasoning efforts) side by side.
 
 This is **off by default** and has no effect on the benchmark unless you opt in. Each
 completed trial becomes a Sigil generation (the agent transcript) plus a score (the
@@ -423,30 +426,86 @@ verifier reward), all attributed to one experiment `run_id`.
 mise run sigil:setup
 ```
 
-This uses the local Sigil SDK checkout (expected as a sibling directory,
-`../sigil-sdk`). Once the SDK is published you can instead `uv pip install sigil-sdk`.
+Then copy `.env.sample` to `.env` and fill in the optional Sigil section for your
+Sigil deployment.
 
-**2. Run a job with live export** (point at your Sigil stack; defaults to `http://localhost:8080`):
+**2. Run a job with live export**:
 
 ```bash
 mise run bench:job -- --model openai/gpt-5.4-nano --task-name query-cpu-metrics \
-  --sigil-experiment-export --sigil-api http://localhost:8080 --sigil-tenant fake
+  --sigil-experiment-export
 ```
 
 The experiment is created before Harbor starts and each trial streams to Sigil as it
 finishes; the run is finalized (succeeded/failed) when the job exits, and a link is printed.
 
+To make the experiment easier to find and compare in Sigil, add a name,
+description, and repeatable tags:
+
+```bash
+mise run bench:job -- \
+  --model openai/gpt-5.4-nano \
+  --task-name query-cpu-metrics \
+  --sigil-experiment-export \
+  --sigil-name "GPT-5.4 nano o11y-bench sample" \
+  --sigil-description "Single-task smoke run exported from o11y-bench with Sigil experiment tracking." \
+  --sigil-tag model:openai/gpt-5.4-nano \
+  --sigil-tag run:smoke \
+  --sigil-tag dataset:o11y-bench
+```
+
+The `o11y-bench` experiment tag is always included automatically.
+
 **Or export an already-completed job** after the fact:
 
 ```bash
-uv run python -m o11y_bench sigil-export jobs/<job-name> --api http://localhost:8080 --tenant fake
+uv run python -m o11y_bench sigil-export jobs/<job-name>
 ```
 
 Useful flags (both commands): `--sigil-run-id`/`--run-id` (stable id for idempotent
-re-exports), `--sigil-name`/`--name`, `--sigil-tag`/`--tag` (repeatable), and
-`--sigil-sdk-path`/`--sdk-path` (point at a local SDK checkout without installing it).
-Connection defaults also read `SIGIL_API_ENDPOINT`, `SIGIL_TENANT_ID`, and
-`SIGIL_SDK_PYTHON_PATH`.
+re-exports), `--sigil-name`/`--name`, `--sigil-tag`/`--tag` (repeatable),
+`--sigil-api`/`--api`, `--sigil-tenant`/`--tenant`, `--sigil-auth-mode`/`--auth-mode`,
+and `--sigil-auth-token`/`--auth-token`.
+
+Configure the Sigil ingest endpoint, tenant/instance ID, and Grafana Cloud
+access-policy token:
+
+```dotenv
+SIGIL_ENDPOINT=https://sigil-prod-<region>.grafana.net
+SIGIL_AUTH_MODE=basic
+SIGIL_AUTH_TENANT_ID=<grafana-cloud-instance-or-tenant-id>
+SIGIL_AUTH_TOKEN=<grafana-cloud-access-policy-token>
+```
+
+Sigil export has two auth planes:
+
+- Ingest plane: generations/transcripts and scores go to `/api/v1/generations:export`
+  and `/api/v1/scores:export`. o11y-bench configures this from `SIGIL_ENDPOINT`,
+  `SIGIL_AUTH_MODE`, `SIGIL_AUTH_TENANT_ID`, and `SIGIL_AUTH_TOKEN` (or the matching
+  `--sigil-*` / `sigil-export` flags).
+- Eval control plane: experiment create/update/finalize calls go to
+  `/api/v1/eval/experiments...`. The Sigil SDK reads `SIGIL_EVAL_*` directly from
+  the environment at call time; o11y-bench does not plumb those values.
+
+For Grafana Cloud, set both planes. The ingest plane uses a Grafana Cloud
+access-policy token. The eval control plane uses a Grafana service-account token
+through the plugin proxy:
+
+```dotenv
+SIGIL_EVAL_ENDPOINT=https://<stack>.grafana.net
+SIGIL_EVAL_PATH_PREFIX=/api/plugins/grafana-sigil-app/resources
+SIGIL_EVAL_AUTH_TOKEN=<grafana-service-account-token>
+```
+
+`SIGIL_EXPERIMENT_URL_TEMPLATE` is optional. Usually leave it unset; the SDK uses
+`SIGIL_EVAL_ENDPOINT` to build the printed "View in Sigil" link. If you override it,
+use the SDK-supported `{base}` and `{run_id}` placeholders, for example:
+
+```dotenv
+SIGIL_EXPERIMENT_URL_TEMPLATE={base}/a/grafana-sigil-app/evaluation/experiments/{run_id}
+```
+
+See `.env.sample` for the full template.
 
 ## Common Local Commands
 

--- a/mise.toml
+++ b/mise.toml
@@ -14,6 +14,10 @@ run = "uv run python -m scripts.sync_tasks"
 description = "Clean stale Harbor Docker projects and pre-build shared images"
 run = "bash scripts/harbor_preflight.sh"
 
+[tasks."sigil:setup"]
+description = "Opt-in: install the local Sigil SDK so runs can be exported to Sigil"
+run = "uv sync --extra sigil"
+
 # -- Bench --
 
 [tasks."bench:job"]

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
 min_version = "2024.1.0"
 
+[env]
+_.file = ".env"
+
 [tools]
 python = "3.14"
 uv = "0.11.8"
@@ -15,7 +18,7 @@ description = "Clean stale Harbor Docker projects and pre-build shared images"
 run = "bash scripts/harbor_preflight.sh"
 
 [tasks."sigil:setup"]
-description = "Opt-in: install the local Sigil SDK so runs can be exported to Sigil"
+description = "Opt-in: install the Sigil SDK so runs can be exported to Sigil"
 run = "uv sync --extra sigil"
 
 # -- Bench --

--- a/o11y_bench/cli.py
+++ b/o11y_bench/cli.py
@@ -23,6 +23,12 @@ from .harbor import run as run_harbor
 from .resume import compute_task_checksums
 from .run import execute_job, execute_regrade, execute_suite, finalize_job_dir
 from .scenario_clock import SCENARIO_TIME_ENV, current_scenario_time_iso
+from .sigil_export import (
+    SigilExportOptions,
+    SigilExportResult,
+    SigilLiveExporter,
+    export_job_to_sigil,
+)
 
 
 def _extract_option(args: list[str], *names: str) -> str | None:
@@ -82,6 +88,26 @@ def main() -> None:
     )
     job_parser.add_argument("--dry-run", action="store_true")
     job_parser.add_argument("--quiet", action="store_true")
+    job_parser.add_argument(
+        "--sigil-experiment-export",
+        action="store_true",
+        help="Export the completed job to Sigil as an external experiment",
+    )
+    job_parser.add_argument(
+        "--sigil-api", default=os.environ.get("SIGIL_API_ENDPOINT", "http://localhost:8080")
+    )
+    job_parser.add_argument("--sigil-tenant", default=os.environ.get("SIGIL_TENANT_ID", "fake"))
+    job_parser.add_argument("--sigil-run-id")
+    job_parser.add_argument("--sigil-name")
+    job_parser.add_argument("--sigil-description", default="")
+    job_parser.add_argument("--sigil-tag", action="append", default=[])
+    job_parser.add_argument(
+        "--sigil-sdk-path",
+        type=Path,
+        default=Path(os.environ["SIGIL_SDK_PYTHON_PATH"])
+        if os.environ.get("SIGIL_SDK_PYTHON_PATH")
+        else None,
+    )
 
     # --- finalize: stamp checksums + generate per-job report ---
     finalize_parser = subparsers.add_parser(
@@ -101,6 +127,26 @@ def main() -> None:
     regrade_parser.add_argument("--job-name")
     regrade_parser.add_argument("--quiet", action="store_true")
 
+    # --- sigil-export: publish completed job artifacts to Sigil ---
+    sigil_parser = subparsers.add_parser(
+        "sigil-export", help="Export a completed benchmark job to a Sigil experiment"
+    )
+    sigil_parser.add_argument("job_dir", type=Path)
+    sigil_parser.add_argument("--path", type=Path)
+    sigil_parser.add_argument("--api", default=os.environ.get("SIGIL_API_ENDPOINT", "http://localhost:8080"))
+    sigil_parser.add_argument("--tenant", default=os.environ.get("SIGIL_TENANT_ID", "fake"))
+    sigil_parser.add_argument("--run-id")
+    sigil_parser.add_argument("--name")
+    sigil_parser.add_argument("--description", default="")
+    sigil_parser.add_argument("--tag", action="append", default=[])
+    sigil_parser.add_argument(
+        "--sdk-path",
+        type=Path,
+        default=Path(os.environ["SIGIL_SDK_PYTHON_PATH"])
+        if os.environ.get("SIGIL_SDK_PYTHON_PATH")
+        else None,
+    )
+
     args = _parse_args(parser)
 
     match args.command:
@@ -114,6 +160,8 @@ def main() -> None:
             _cmd_finalize(args)
         case "regrade":
             _cmd_regrade(args)
+        case "sigil-export":
+            _cmd_sigil_export(args)
 
 
 def _parse_args(parser: argparse.ArgumentParser) -> argparse.Namespace:
@@ -199,7 +247,21 @@ def _cmd_job(args: argparse.Namespace) -> None:
     if not args.dry_run:
         run_preflight(quiet=args.quiet)
 
-    result = execute_job(spec, dry_run=args.dry_run, quiet=args.quiet)
+    sigil_exporter = None
+    if getattr(args, "sigil_experiment_export", False) and not args.dry_run:
+        sigil_exporter = SigilLiveExporter(
+            spec.jobs_dir / spec.job_name,
+            spec.tasks_dir,
+            _sigil_options_from_args(args),
+        )
+
+    execute_kwargs = {"dry_run": args.dry_run, "quiet": args.quiet}
+    if sigil_exporter is not None:
+        execute_kwargs["sigil_exporter"] = sigil_exporter
+    result = execute_job(spec, **execute_kwargs)
+    export_result = getattr(sigil_exporter, "last_result", None)
+    if export_result is not None:
+        _print_sigil_export_result(export_result)
     if result.harbor_exit_code and result.harbor_exit_code != 0:
         raise SystemExit(result.harbor_exit_code)
 
@@ -233,6 +295,55 @@ def _cmd_regrade(args: argparse.Namespace) -> None:
             raise SystemExit(f"No job dir found for --job-name {args.job_name!r} under {target}")
         target = latest
     execute_regrade(target, tasks_dir=tasks_dir, quiet=args.quiet)
+
+
+def _cmd_sigil_export(args: argparse.Namespace) -> None:
+    _export_job_result_to_sigil(
+        args,
+        normalize_repo_path(ROOT, args.job_dir),
+        _resolve_tasks_path(args.path),
+    )
+
+
+def _export_job_result_to_sigil(
+    args: argparse.Namespace, job_dir: Path, tasks_dir: Path
+) -> SigilExportResult:
+    result = export_job_to_sigil(job_dir, tasks_dir, _sigil_options_from_args(args))
+    print(_format_sigil_export_result(result))
+    return result
+
+
+def _format_sigil_export_result(result: SigilExportResult) -> str:
+    return (
+        f"Exported {result.generation_count} generation(s), {result.score_count} score(s) "
+        f"to Sigil run {result.run_id}\nView in Sigil: {result.url}"
+    )
+
+
+def _print_sigil_export_result(result: SigilExportResult) -> None:
+    print(_format_sigil_export_result(result))
+
+
+def _sigil_options_from_args(args: argparse.Namespace) -> SigilExportOptions:
+    # The `job` and `sigil-export` subparsers name the same options differently
+    # (`--sigil-api` vs `--api`), so accept either spelling.
+    def _opt(*names: str, default: str = "") -> str:
+        for name in names:
+            value = getattr(args, name, None)
+            if value:
+                return str(value)
+        return default
+
+    sdk_path = getattr(args, "sdk_path", None) or getattr(args, "sigil_sdk_path", None)
+    return SigilExportOptions(
+        api=_opt("api", "sigil_api", default="http://localhost:8080"),
+        tenant=_opt("tenant", "sigil_tenant", default="fake"),
+        run_id=_opt("run_id", "sigil_run_id"),
+        name=_opt("name", "sigil_name"),
+        description=_opt("description", "sigil_description"),
+        tags=list(getattr(args, "tag", None) or getattr(args, "sigil_tag", None) or []),
+        sdk_path=Path(sdk_path) if sdk_path is not None else None,
+    )
 
 
 def _resolve_tasks_path(path: Path | None) -> Path:

--- a/o11y_bench/cli.py
+++ b/o11y_bench/cli.py
@@ -94,20 +94,19 @@ def main() -> None:
         help="Export the completed job to Sigil as an external experiment",
     )
     job_parser.add_argument(
-        "--sigil-api", default=os.environ.get("SIGIL_API_ENDPOINT", "http://localhost:8080")
+        "--sigil-api",
+        default=os.environ.get("SIGIL_ENDPOINT", ""),
     )
-    job_parser.add_argument("--sigil-tenant", default=os.environ.get("SIGIL_TENANT_ID", "fake"))
+    job_parser.add_argument(
+        "--sigil-tenant",
+        default=os.environ.get("SIGIL_AUTH_TENANT_ID", ""),
+    )
+    job_parser.add_argument("--sigil-auth-mode", default=os.environ.get("SIGIL_AUTH_MODE", "basic"))
+    job_parser.add_argument("--sigil-auth-token", default=os.environ.get("SIGIL_AUTH_TOKEN"))
     job_parser.add_argument("--sigil-run-id")
     job_parser.add_argument("--sigil-name")
     job_parser.add_argument("--sigil-description", default="")
     job_parser.add_argument("--sigil-tag", action="append", default=[])
-    job_parser.add_argument(
-        "--sigil-sdk-path",
-        type=Path,
-        default=Path(os.environ["SIGIL_SDK_PYTHON_PATH"])
-        if os.environ.get("SIGIL_SDK_PYTHON_PATH")
-        else None,
-    )
 
     # --- finalize: stamp checksums + generate per-job report ---
     finalize_parser = subparsers.add_parser(
@@ -133,19 +132,20 @@ def main() -> None:
     )
     sigil_parser.add_argument("job_dir", type=Path)
     sigil_parser.add_argument("--path", type=Path)
-    sigil_parser.add_argument("--api", default=os.environ.get("SIGIL_API_ENDPOINT", "http://localhost:8080"))
-    sigil_parser.add_argument("--tenant", default=os.environ.get("SIGIL_TENANT_ID", "fake"))
+    sigil_parser.add_argument(
+        "--api",
+        default=os.environ.get("SIGIL_ENDPOINT", ""),
+    )
+    sigil_parser.add_argument(
+        "--tenant",
+        default=os.environ.get("SIGIL_AUTH_TENANT_ID", ""),
+    )
+    sigil_parser.add_argument("--auth-mode", default=os.environ.get("SIGIL_AUTH_MODE", "basic"))
+    sigil_parser.add_argument("--auth-token", default=os.environ.get("SIGIL_AUTH_TOKEN"))
     sigil_parser.add_argument("--run-id")
     sigil_parser.add_argument("--name")
     sigil_parser.add_argument("--description", default="")
     sigil_parser.add_argument("--tag", action="append", default=[])
-    sigil_parser.add_argument(
-        "--sdk-path",
-        type=Path,
-        default=Path(os.environ["SIGIL_SDK_PYTHON_PATH"])
-        if os.environ.get("SIGIL_SDK_PYTHON_PATH")
-        else None,
-    )
 
     args = _parse_args(parser)
 
@@ -249,10 +249,12 @@ def _cmd_job(args: argparse.Namespace) -> None:
 
     sigil_exporter = None
     if getattr(args, "sigil_experiment_export", False) and not args.dry_run:
+        sigil_options = _sigil_options_from_args(args)
+        _print_sigil_publish_start(sigil_options)
         sigil_exporter = SigilLiveExporter(
             spec.jobs_dir / spec.job_name,
             spec.tasks_dir,
-            _sigil_options_from_args(args),
+            sigil_options,
         )
 
     execute_kwargs = {"dry_run": args.dry_run, "quiet": args.quiet}
@@ -308,7 +310,9 @@ def _cmd_sigil_export(args: argparse.Namespace) -> None:
 def _export_job_result_to_sigil(
     args: argparse.Namespace, job_dir: Path, tasks_dir: Path
 ) -> SigilExportResult:
-    result = export_job_to_sigil(job_dir, tasks_dir, _sigil_options_from_args(args))
+    sigil_options = _sigil_options_from_args(args)
+    _print_sigil_publish_start(sigil_options)
+    result = export_job_to_sigil(job_dir, tasks_dir, sigil_options)
     print(_format_sigil_export_result(result))
     return result
 
@@ -324,6 +328,18 @@ def _print_sigil_export_result(result: SigilExportResult) -> None:
     print(_format_sigil_export_result(result))
 
 
+def _print_sigil_publish_start(options: SigilExportOptions) -> None:
+    stack_url = os.environ.get("SIGIL_EVAL_ENDPOINT", "").rstrip("/")
+    ingest_endpoint = options.api.rstrip("/") if options.api else "<unset>"
+    print("Publishing results to Grafana AI o11y")
+    if stack_url:
+        print(f"Sigil stack URL: {stack_url}")
+    else:
+        print("Sigil stack URL: <unset; set SIGIL_EVAL_ENDPOINT>")
+    print(f"Sigil ingest endpoint: {ingest_endpoint}")
+    print(f"Sigil auth mode: {options.auth_mode or 'basic'}")
+
+
 def _sigil_options_from_args(args: argparse.Namespace) -> SigilExportOptions:
     # The `job` and `sigil-export` subparsers name the same options differently
     # (`--sigil-api` vs `--api`), so accept either spelling.
@@ -334,15 +350,15 @@ def _sigil_options_from_args(args: argparse.Namespace) -> SigilExportOptions:
                 return str(value)
         return default
 
-    sdk_path = getattr(args, "sdk_path", None) or getattr(args, "sigil_sdk_path", None)
     return SigilExportOptions(
-        api=_opt("api", "sigil_api", default="http://localhost:8080"),
-        tenant=_opt("tenant", "sigil_tenant", default="fake"),
+        api=_opt("api", "sigil_api"),
+        tenant=_opt("tenant", "sigil_tenant"),
+        auth_mode=_opt("auth_mode", "sigil_auth_mode", default="basic"),
+        auth_token=_opt("auth_token", "sigil_auth_token"),
         run_id=_opt("run_id", "sigil_run_id"),
         name=_opt("name", "sigil_name"),
         description=_opt("description", "sigil_description"),
         tags=list(getattr(args, "tag", None) or getattr(args, "sigil_tag", None) or []),
-        sdk_path=Path(sdk_path) if sdk_path is not None else None,
     )
 
 

--- a/o11y_bench/run.py
+++ b/o11y_bench/run.py
@@ -78,6 +78,28 @@ def _print_job_summary(result: JobResult) -> None:
     print(f"{result.job_name}: {message}")
 
 
+def _run_harbor_with_live_export(
+    command: list[str],
+    *,
+    sigil_exporter: Any | None,
+) -> int:
+    if sigil_exporter is None:
+        return run_harbor(command, forward_signals=False)
+
+    sigil_exporter.start()
+    exit_code = 1
+    error = ""
+    try:
+        exit_code = run_harbor(command, forward_signals=False)
+        return exit_code
+    except BaseException as exc:
+        error = str(exc)
+        raise
+    finally:
+        status = "succeeded" if exit_code == 0 and not error else "failed"
+        sigil_exporter.finish(status=status, error=error)
+
+
 def _selected_task_names(spec: JobSpec) -> list[str]:
     if spec.task_names:
         return list(spec.task_names)
@@ -490,7 +512,13 @@ def execute_regrade(target_dir: Path, *, tasks_dir: Path, quiet: bool = False) -
         suite_report.write_report(target_dir, tasks_dir=tasks_dir, quiet=quiet)
 
 
-def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) -> JobResult:
+def execute_job(
+    spec: JobSpec,
+    *,
+    dry_run: bool = False,
+    quiet: bool = False,
+    sigil_exporter: Any | None = None,
+) -> JobResult:
     """Single-pass: plan, repair, run harbor, finalize."""
     task_checksums = compute_task_checksums(spec.tasks_dir)
     job_dir = spec.jobs_dir / spec.job_name
@@ -513,7 +541,10 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
             if quiet:
                 _print_job_summary(result)
             return result
-        fresh_harbor_exit_code = run_harbor(build_command(spec, quiet=quiet), forward_signals=False)
+        fresh_harbor_exit_code = _run_harbor_with_live_export(
+            build_command(spec, quiet=quiet),
+            sigil_exporter=sigil_exporter,
+        )
         report_path = finalize_job_dir(job_dir, spec.tasks_dir, task_checksums)
         result = JobResult(
             "fresh",
@@ -554,6 +585,8 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
         return result
 
     if not needs_repair and not needs_harbor:
+        if sigil_exporter is not None:
+            sigil_exporter.export_existing()
         result = JobResult("up_to_date", spec.job_name)
         if quiet:
             _print_job_summary(result)
@@ -567,18 +600,20 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
 
     rerun_harbor_exit_code: int | None = None
     if needs_harbor:
-        rerun_harbor_exit_code = run_harbor(
+        rerun_harbor_exit_code = _run_harbor_with_live_export(
             build_resume_command(
                 str(job_dir / "config.json"),
                 quiet=quiet,
                 harbor_args=spec.harbor_args,
             ),
-            forward_signals=False,
+            sigil_exporter=sigil_exporter,
         )
 
     report_path = finalize_job_dir(job_dir, spec.tasks_dir, task_checksums)
     if report_path and not quiet:
         print(f"Report: {report_path}")
+    if sigil_exporter is not None and not needs_harbor:
+        sigil_exporter.export_existing()
 
     result = JobResult(
         "ran",

--- a/o11y_bench/sigil_export.py
+++ b/o11y_bench/sigil_export.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import sys
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -38,13 +37,14 @@ from reporting.report_data import (
 
 @dataclass(slots=True)
 class SigilExportOptions:
-    api: str = "http://localhost:8080"
-    tenant: str = "fake"
+    api: str = ""
+    tenant: str = ""
+    auth_mode: str = "basic"
+    auth_token: str = ""
     run_id: str = ""
     name: str = ""
     description: str = ""
     tags: list[str] = field(default_factory=lambda: ["o11y-bench"])
-    sdk_path: Path | None = None
 
 
 @dataclass(slots=True)
@@ -154,7 +154,7 @@ class SigilLiveExporter:
     def _connect(self) -> None:
         if self._run is not None:
             return
-        sdk = _import_sdk(self.options.sdk_path)
+        sdk = _import_sdk()
         self._sdk = sdk
         self._client = _make_client(sdk, self.options)
         self._categories = load_task_categories(self.tasks_dir)
@@ -303,13 +303,19 @@ def _score_output(
 
 def _make_client(sdk: Any, options: SigilExportOptions) -> Any:
     api = options.api.rstrip("/")
+    if not api:
+        raise ValueError("Sigil export requires SIGIL_ENDPOINT or --sigil-api/--api.")
+    auth = sdk.AuthConfig(mode=options.auth_mode or "basic", tenant_id=options.tenant)
+    if options.auth_token:
+        auth.bearer_token = options.auth_token
+        auth.basic_password = options.auth_token
     return sdk.Client(
         sdk.ClientConfig(
             api=sdk.ApiConfig(endpoint=api),
             generation_export=sdk.GenerationExportConfig(
                 protocol="http",
                 endpoint=f"{api}/api/v1/generations:export",
-                auth=sdk.AuthConfig(mode="tenant", tenant_id=options.tenant),
+                auth=auth,
             ),
         )
     )
@@ -511,16 +517,12 @@ def _parse_datetime(value: Any) -> datetime | None:
         return None
 
 
-def _import_sdk(sdk_path: Path | None = None) -> Any:
+def _import_sdk() -> Any:
     """Imports the Sigil SDK lazily, with a friendly opt-in error if it's absent.
 
-    ``sdk_path`` (or ``SIGIL_SDK_PYTHON_PATH``) is an optional escape hatch to
-    point at a local SDK checkout without installing it; normally the SDK is
-    installed into the venv via ``mise run sigil:setup``.
+    The SDK is installed into the venv via ``mise run sigil:setup``.
     """
 
-    if sdk_path is not None:
-        sys.path.insert(0, str(sdk_path.resolve()))
     try:
         import sigil_sdk
     except ImportError as exc:
@@ -528,7 +530,6 @@ def _import_sdk(sdk_path: Path | None = None) -> Any:
             "Sigil export is an opt-in feature and needs the Sigil Python SDK, which is "
             "not installed in this environment.\n"
             "Enable it with:\n"
-            "    mise run sigil:setup\n"
-            "or point at a local SDK checkout with --sigil-sdk-path / SIGIL_SDK_PYTHON_PATH."
+            "    mise run sigil:setup"
         ) from exc
     return sigil_sdk

--- a/o11y_bench/sigil_export.py
+++ b/o11y_bench/sigil_export.py
@@ -1,0 +1,534 @@
+"""Export completed o11y-bench job artifacts to Sigil experiments.
+
+This is an **optional, opt-in** feature. It is only triggered by the
+``--sigil-experiment-export`` flag on ``o11y_bench job`` or by the standalone
+``o11y_bench sigil-export`` subcommand, and it requires the Sigil Python SDK
+(install it with ``mise run sigil:setup``). The SDK is imported lazily, so
+importing this module — and the rest of o11y-bench — works fine when the SDK is
+not installed.
+
+It rides on the Sigil SDK's generic experiment runner (``ExperimentRun``): each
+completed trial becomes a Sigil generation (the agent transcript) plus a score
+(the verifier reward), attributed to one external experiment ``run_id`` so runs
+can be browsed and compared in Sigil.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from grading.models import Message as BenchMessage
+from grading.transcript_parser import parse_transcript
+from reporting.report_data import (
+    agent_result_metrics,
+    agent_seconds,
+    load_task_categories,
+    load_trials,
+    reward_counts_as_pass,
+    trial_reasoning_effort,
+)
+
+
+@dataclass(slots=True)
+class SigilExportOptions:
+    api: str = "http://localhost:8080"
+    tenant: str = "fake"
+    run_id: str = ""
+    name: str = ""
+    description: str = ""
+    tags: list[str] = field(default_factory=lambda: ["o11y-bench"])
+    sdk_path: Path | None = None
+
+
+@dataclass(slots=True)
+class SigilExportResult:
+    run_id: str
+    generation_count: int
+    score_count: int
+    url: str
+
+
+class SigilLiveExporter:
+    """Live exporter for an o11y-bench job.
+
+    It creates the Sigil experiment before Harbor starts, exports each completed
+    trial as soon as its result artifact is available, then marks the experiment
+    terminal after Harbor exits.
+    """
+
+    def __init__(
+        self,
+        job_dir: Path,
+        tasks_dir: Path,
+        options: SigilExportOptions,
+        *,
+        poll_interval_seconds: float = 2.0,
+    ) -> None:
+        self.job_dir = job_dir.resolve()
+        self.tasks_dir = tasks_dir.resolve()
+        self.options = options
+        self.poll_interval_seconds = poll_interval_seconds
+        self.run_id = options.run_id or _default_run_id(self.job_dir)
+        self._sdk: Any | None = None
+        self._client: Any | None = None
+        self._run: Any | None = None
+        self._categories: dict[str, str] = {}
+        self._exported_trial_ids: set[str] = set()
+        self._generation_count = 0
+        self._score_count = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._error: Exception | None = None
+        self.last_result: SigilExportResult | None = None
+
+    @property
+    def url(self) -> str:
+        if self._client is not None:
+            return str(self._client.experiment_url(self.run_id))
+        return f"{self.options.api.rstrip('/')}/a/grafana-sigil-app/evaluation/experiments/{self.run_id}"
+
+    def start(self) -> None:
+        self._connect()
+        self._thread = threading.Thread(
+            target=self._poll_loop, name="sigil-live-export", daemon=True
+        )
+        self._thread.start()
+
+    def finish(self, *, status: str = "succeeded", error: str = "") -> SigilExportResult:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(5.0, self.poll_interval_seconds * 2))
+        self.scan_once()
+        if self._client is not None:
+            self._client.complete_experiment(
+                self.run_id,
+                status=status,
+                score_count=self._score_count,
+                error=error,
+                metadata={
+                    "source": "o11y-bench",
+                    "job_name": self.job_dir.name,
+                    "exported_generations": self._generation_count,
+                    "exported_scores": self._score_count,
+                },
+            )
+            self._client.shutdown()
+        if self._error is not None:
+            raise RuntimeError(f"Sigil live export failed: {self._error}") from self._error
+        self.last_result = SigilExportResult(
+            run_id=self.run_id,
+            generation_count=self._generation_count,
+            score_count=self._score_count,
+            url=self.url,
+        )
+        return self.last_result
+
+    def export_existing(self) -> SigilExportResult:
+        self._connect()
+        self.scan_once()
+        return self.finish(status="succeeded")
+
+    def scan_once(self) -> None:
+        if self._run is None:
+            return
+        if not self.job_dir.exists():
+            return
+        for trial in load_trials(self.job_dir):
+            trial_dir = Path(str(trial["__result_path"])).parent
+            trial_id = trial_dir.name
+            reward = ((trial.get("verifier_result") or {}).get("rewards") or {}).get("reward")
+            if trial_id in self._exported_trial_ids or reward is None:
+                continue
+            self._export_trial(trial, trial_dir, reward)
+
+    # --- setup -------------------------------------------------------------- #
+
+    def _connect(self) -> None:
+        if self._run is not None:
+            return
+        sdk = _import_sdk(self.options.sdk_path)
+        self._sdk = sdk
+        self._client = _make_client(sdk, self.options)
+        self._categories = load_task_categories(self.tasks_dir)
+        self._create_or_update_experiment()
+        # ExperimentRun handles run_id tagging on generations + deterministic,
+        # idempotent score ids; we drive it manually (no context manager) so it
+        # stays open across Harbor's lifetime.
+        self._run = sdk.ExperimentRun(
+            client=self._client,
+            run_id=self.run_id,
+            name=self.options.name or f"o11y-bench {self.job_dir.name}",
+            dataset={"id": "o11y-bench"},
+            candidate={"job_name": self.job_dir.name},
+            upload="continuous",
+            agent_name="o11y-bench",
+        )
+
+    def _create_or_update_experiment(self) -> None:
+        sdk, client = self._sdk, self._client
+        if sdk is None or client is None:
+            return
+        tags = _normalized_tags(self.options.tags)
+        name = self.options.name or f"o11y-bench {self.job_dir.name}"
+        try:
+            client.create_experiment(
+                sdk.CreateExperimentRequest(
+                    run_id=self.run_id,
+                    name=name,
+                    source="external",
+                    description=self.options.description,
+                    tags=tags,
+                    metadata={
+                        "source": "o11y-bench",
+                        "job_name": self.job_dir.name,
+                        "job_dir": str(self.job_dir),
+                        "tasks_dir": str(self.tasks_dir),
+                    },
+                )
+            )
+        except sdk.ConflictError:
+            # Re-running an export against an existing run: reopen it so we can
+            # append any newly completed trials, then re-finalize on finish().
+            client.update_experiment(
+                self.run_id,
+                sdk.UpdateExperimentRequest(
+                    name=name,
+                    description=self.options.description,
+                    tags=tags,
+                    status="running",
+                ),
+            )
+
+    # --- per-trial export --------------------------------------------------- #
+
+    def _poll_loop(self) -> None:
+        while not self._stop.wait(self.poll_interval_seconds):
+            try:
+                self.scan_once()
+            except Exception as exc:
+                with self._lock:
+                    if self._error is None:
+                        self._error = exc
+                self._stop.set()
+
+    def _export_trial(self, trial: dict[str, Any], trial_dir: Path, reward: Any) -> None:
+        sdk, run = self._sdk, self._run
+        if sdk is None or run is None:
+            return
+        task_name = str(trial.get("task_name") or trial_dir.name.split("__", 1)[0])
+        trial_id = trial_dir.name
+        category = self._categories.get(task_name, "unknown")
+        generation_id = _stable_id("o11y-gen", self.run_id, trial_id)
+        conversation_id = _stable_id("o11y-conv", self.run_id, trial_id)
+
+        # One conversation per trial; start_generation tags the generation with
+        # the experiment run_id and captures its id for the score below.
+        run.reset_capture(conversation_id=conversation_id)
+        with run.start_generation(
+            _generation_start(
+                sdk, trial, trial_dir, generation_id, conversation_id, task_name, category
+            )
+        ) as recorder:
+            recorder.set_result(
+                _generation_result(sdk, trial, trial_dir, generation_id, conversation_id, task_name)
+            )
+
+        run.add_scores(
+            [_score_output(sdk, trial, trial_dir, reward, self.job_dir.name, task_name, category)],
+            item=sdk.DatasetItem(id=task_name),
+            generation_ids=run.produced_generation_ids,
+            trial_id=trial_id,
+        )
+        self._exported_trial_ids.add(trial_id)
+        self._generation_count += 1
+        self._score_count = int(run.accepted_scores)
+
+
+def export_job_to_sigil(
+    job_dir: Path, tasks_dir: Path, options: SigilExportOptions
+) -> SigilExportResult:
+    exporter = SigilLiveExporter(job_dir, tasks_dir, options, poll_interval_seconds=0.0)
+    result = exporter.export_existing()
+    if result.generation_count == 0:
+        raise ValueError(f"no completed scored trial result.json files found under {job_dir}")
+    return result
+
+
+# --- generation + score mapping -------------------------------------------- #
+
+
+def _score_output(
+    sdk: Any,
+    trial: dict[str, Any],
+    trial_dir: Path,
+    reward: Any,
+    job_name: str,
+    task_name: str,
+    task_category: str,
+) -> Any:
+    cost_usd, n_input_tokens, n_cache_tokens, n_output_tokens = agent_result_metrics(trial)
+    total_tokens = n_input_tokens + n_cache_tokens + n_output_tokens
+    return sdk.ScoreOutput(
+        evaluator_id="o11y-bench.verifier",
+        evaluator_version=_evaluator_version(trial),
+        score_key="reward",
+        value=sdk.ScoreValue(number=float(reward)),
+        passed=reward_counts_as_pass(trial),
+        explanation=_score_explanation(trial_dir),
+        metadata={
+            "source": "o11y-bench",
+            "job_name": job_name,
+            "task_id": task_name,
+            "task_category": task_category,
+            "cost_usd": cost_usd,
+            "input_tokens": n_input_tokens,
+            "cache_tokens": n_cache_tokens,
+            "output_tokens": n_output_tokens,
+            "total_tokens": total_tokens,
+            "wall_time_seconds": agent_seconds(trial),
+            "model": _model_name(trial),
+            "reasoning_effort": trial_reasoning_effort(trial),
+            "result_path": str(trial_dir / "result.json"),
+        },
+    )
+
+
+def _make_client(sdk: Any, options: SigilExportOptions) -> Any:
+    api = options.api.rstrip("/")
+    return sdk.Client(
+        sdk.ClientConfig(
+            api=sdk.ApiConfig(endpoint=api),
+            generation_export=sdk.GenerationExportConfig(
+                protocol="http",
+                endpoint=f"{api}/api/v1/generations:export",
+                auth=sdk.AuthConfig(mode="tenant", tenant_id=options.tenant),
+            ),
+        )
+    )
+
+
+def _generation_start(
+    sdk: Any,
+    trial: dict[str, Any],
+    trial_dir: Path,
+    generation_id: str,
+    conversation_id: str,
+    task_name: str,
+    task_category: str,
+) -> Any:
+    cost_usd, *_ = agent_result_metrics(trial)
+    transcript = parse_transcript(trial_dir / "agent")
+    system_prompt, _input_messages, _output_messages = _split_transcript_messages(
+        sdk, transcript.messages
+    )
+    model_provider, model_name = _model_ref(trial)
+    return sdk.GenerationStart(
+        id=generation_id,
+        conversation_id=conversation_id,
+        conversation_title=task_name,
+        model=sdk.ModelRef(provider=model_provider, name=model_name),
+        operation_name="o11y-bench trial",
+        agent_version=trial_reasoning_effort(trial),
+        system_prompt=system_prompt,
+        tags={
+            "source": "o11y-bench",
+            "task_id": task_name,
+            "task_category": task_category,
+        },
+        metadata={
+            "source": "o11y-bench",
+            "task_id": task_name,
+            "task_category": task_category,
+            "trial_id": trial_dir.name,
+            "cost_usd": cost_usd,
+        },
+        started_at=_parse_datetime((trial.get("agent_execution") or {}).get("started_at")),
+    )
+
+
+def _generation_result(
+    sdk: Any,
+    trial: dict[str, Any],
+    trial_dir: Path,
+    generation_id: str,
+    conversation_id: str,
+    task_name: str,
+) -> Any:
+    _cost_usd, n_input_tokens, n_cache_tokens, n_output_tokens = agent_result_metrics(trial)
+    transcript = parse_transcript(trial_dir / "agent")
+    _system_prompt, input_messages, output_messages = _split_transcript_messages(
+        sdk, transcript.messages
+    )
+    if not input_messages:
+        input_messages = [sdk.user_text_message(f"Run o11y-bench task {task_name}.")]
+    if not output_messages:
+        output_messages = [sdk.assistant_text_message("No assistant transcript was captured.")]
+    model_provider, model_name = _model_ref(trial)
+    return sdk.Generation(
+        id=generation_id,
+        conversation_id=conversation_id,
+        conversation_title=task_name,
+        model=sdk.ModelRef(provider=model_provider, name=model_name),
+        response_model=_model_name(trial),
+        input=input_messages,
+        output=output_messages,
+        usage=sdk.TokenUsage(
+            input_tokens=n_input_tokens,
+            cache_read_input_tokens=n_cache_tokens,
+            output_tokens=n_output_tokens,
+            total_tokens=n_input_tokens + n_cache_tokens + n_output_tokens,
+        ),
+        metadata={"trial_id": trial_dir.name, "run_id": generation_id},
+    )
+
+
+def _split_transcript_messages(
+    sdk: Any, messages: list[BenchMessage]
+) -> tuple[str, list[Any], list[Any]]:
+    system_parts: list[str] = []
+    input_messages: list[Any] = []
+    output_messages: list[Any] = []
+    for message in messages:
+        if message.role == "system":
+            if message.content:
+                system_parts.append(message.content)
+            continue
+        mapped = _map_transcript_message(sdk, message)
+        if mapped is None:
+            continue
+        if message.role == "user":
+            input_messages.append(mapped)
+        else:
+            output_messages.append(mapped)
+    return "\n\n".join(system_parts), input_messages, output_messages
+
+
+def _map_transcript_message(sdk: Any, message: BenchMessage) -> Any | None:
+    parts = []
+    if message.thinking_content:
+        parts.append(sdk.thinking_part(message.thinking_content))
+    if message.content:
+        parts.append(sdk.text_part(message.content))
+    if message.tool_calls:
+        for call in message.tool_calls:
+            parts.append(
+                sdk.tool_call_part(
+                    sdk.ToolCall(
+                        id=call.id,
+                        name=call.name,
+                        input_json=json.dumps(call.arguments).encode(),
+                    )
+                )
+            )
+    if message.tool_results:
+        for result in message.tool_results:
+            parts.append(
+                sdk.tool_result_part(
+                    sdk.ToolResult(
+                        tool_call_id=result.tool_call_id,
+                        content=result.content,
+                    )
+                )
+            )
+    if not parts:
+        return None
+    role = sdk.MessageRole.USER if message.role == "user" else sdk.MessageRole.ASSISTANT
+    if message.role == "tool":
+        role = sdk.MessageRole.TOOL
+    return sdk.Message(role=role, parts=parts)
+
+
+def _score_explanation(trial_dir: Path) -> str:
+    details_path = trial_dir / "verifier" / "grading_details.json"
+    if not details_path.exists():
+        return ""
+    try:
+        details = json.loads(details_path.read_text())
+    except Exception:
+        return ""
+    explanations = [
+        str(value)
+        for key, value in details.items()
+        if isinstance(key, str) and key.startswith("explanation:") and value
+    ]
+    return "\n".join(explanations)
+
+
+def _evaluator_version(trial: dict[str, Any]) -> str:
+    checksum = trial.get("task_checksum")
+    if isinstance(checksum, str) and checksum:
+        return checksum
+    return "unknown"
+
+
+def _model_name(trial: dict[str, Any]) -> str:
+    model_info = (trial.get("agent_info") or {}).get("model_info") or {}
+    return str(model_info.get("name") or "")
+
+
+def _model_ref(trial: dict[str, Any]) -> tuple[str, str]:
+    model_info = (trial.get("agent_info") or {}).get("model_info") or {}
+    provider = str(model_info.get("provider") or "")
+    name = str(model_info.get("name") or "")
+    if not provider and "/" in name:
+        provider, name = name.split("/", 1)
+    return provider, name
+
+
+def _default_run_id(job_dir: Path) -> str:
+    digest = hashlib.sha1(str(job_dir.resolve()).encode()).hexdigest()[:10]
+    return f"o11y-bench-{job_dir.name}-{digest}"
+
+
+def _stable_id(prefix: str, *parts: str) -> str:
+    digest = hashlib.sha1("\x1f".join(parts).encode()).hexdigest()[:24]
+    return f"{prefix}-{digest}"
+
+
+def _normalized_tags(tags: list[str]) -> list[str]:
+    out = []
+    for tag in ["o11y-bench", *tags]:
+        normalized = tag.strip()
+        if normalized and normalized not in out:
+            out.append(normalized)
+    return out
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _import_sdk(sdk_path: Path | None = None) -> Any:
+    """Imports the Sigil SDK lazily, with a friendly opt-in error if it's absent.
+
+    ``sdk_path`` (or ``SIGIL_SDK_PYTHON_PATH``) is an optional escape hatch to
+    point at a local SDK checkout without installing it; normally the SDK is
+    installed into the venv via ``mise run sigil:setup``.
+    """
+
+    if sdk_path is not None:
+        sys.path.insert(0, str(sdk_path.resolve()))
+    try:
+        import sigil_sdk
+    except ImportError as exc:
+        raise RuntimeError(
+            "Sigil export is an opt-in feature and needs the Sigil Python SDK, which is "
+            "not installed in this environment.\n"
+            "Enable it with:\n"
+            "    mise run sigil:setup\n"
+            "or point at a local SDK checkout with --sigil-sdk-path / SIGIL_SDK_PYTHON_PATH."
+        ) from exc
+    return sigil_sdk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,7 @@ dependencies = [
 [project.optional-dependencies]
 # Opt-in: exporting benchmark runs to Sigil. Not installed by default and has no
 # effect on the core benchmark. Enable with `mise run sigil:setup`.
-sigil = ["sigil-sdk>=0.7.0"]
-
-[tool.uv.sources]
-# Use the local (unpublished) Sigil SDK checkout for the `sigil` extra. Assumes
-# sigil-sdk is a sibling of this repo; override with `uv sync --extra sigil
-# --no-sources` once the SDK is published to PyPI.
-sigil-sdk = { path = "../sigil-sdk/python", editable = true }
+sigil = ["sigil-sdk==0.8.0"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,17 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.optional-dependencies]
+# Opt-in: exporting benchmark runs to Sigil. Not installed by default and has no
+# effect on the core benchmark. Enable with `mise run sigil:setup`.
+sigil = ["sigil-sdk>=0.7.0"]
+
+[tool.uv.sources]
+# Use the local (unpublished) Sigil SDK checkout for the `sigil` extra. Assumes
+# sigil-sdk is a sibling of this repo; override with `uv sync --extra sigil
+# --no-sources` once the SDK is published to PyPI.
+sigil-sdk = { path = "../sigil-sdk/python", editable = true }
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -472,8 +472,9 @@ def test_cmd_job_rejects_agent_and_agent_import_path_together() -> None:
         cli._cmd_job(args)
 
 
-def test_cmd_job_passes_live_sigil_exporter_when_flag_enabled(monkeypatch) -> None:
+def test_cmd_job_passes_live_sigil_exporter_when_flag_enabled(monkeypatch, capsys) -> None:
     monkeypatch.setattr(cli, "run_preflight", lambda *, quiet=False: None)
+    monkeypatch.setenv("SIGIL_EVAL_ENDPOINT", "https://grafana-stack.grafana.net")
 
     execute_calls: list[tuple[config.JobSpec, object]] = []
     exporter_calls: list[tuple[object, object, object]] = []
@@ -516,13 +517,14 @@ def test_cmd_job_passes_live_sigil_exporter_when_flag_enabled(monkeypatch) -> No
         dry_run=False,
         quiet=True,
         sigil_experiment_export=True,
-        sigil_api="http://localhost:8080",
-        sigil_tenant="fake",
+        sigil_api="https://sigil-prod-us-central1.grafana.net",
+        sigil_tenant="grafana-cloud-tenant",
+        sigil_auth_mode="basic",
+        sigil_auth_token="grafana-cloud-access-policy-token",
         sigil_run_id="o11y-run-1",
         sigil_name="o11y run",
         sigil_description="",
         sigil_tag=["o11y-bench", "opencode"],
-        sigil_sdk_path=None,
     )
 
     cli._cmd_job(args)
@@ -533,8 +535,18 @@ def test_cmd_job_passes_live_sigil_exporter_when_flag_enabled(monkeypatch) -> No
     job_dir, tasks_dir, options = exporter_calls[0]
     assert job_dir == config.ROOT / "jobs" / "openai-gpt-5-4-nano-off-opencode-k1"
     assert tasks_dir == config.TASKS_DIR
+    assert options.api == "https://sigil-prod-us-central1.grafana.net"
+    assert options.tenant == "grafana-cloud-tenant"
+    assert options.auth_mode == "basic"
+    assert options.auth_token == "grafana-cloud-access-policy-token"
     assert options.run_id == "o11y-run-1"
     assert options.tags == ["o11y-bench", "opencode"]
+
+    captured = capsys.readouterr()
+    assert "Publishing results to Grafana AI o11y" in captured.out
+    assert "Sigil stack URL: https://grafana-stack.grafana.net" in captured.out
+    assert "Sigil ingest endpoint: https://sigil-prod-us-central1.grafana.net" in captured.out
+    assert "grafana-cloud-access-policy-token" not in captured.out
 
 
 def test_regrade_job_dir_updates_verifier_outputs(monkeypatch, tmp_path) -> None:

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -126,6 +126,33 @@ def test_execute_job_resumes_from_saved_config(monkeypatch, tmp_path) -> None:
     assert kwargs == {"forward_signals": False}
 
 
+def test_run_harbor_with_live_export_starts_before_harbor_and_finishes_after(monkeypatch) -> None:
+    events: list[str] = []
+
+    class FakeExporter:
+        def start(self):
+            events.append("start")
+
+        def finish(self, *, status: str, error: str = ""):
+            events.append(f"finish:{status}:{error}")
+
+    def fake_run_harbor(command: list[str], **kwargs: object) -> int:
+        events.append("harbor")
+        assert command == ["harbor", "run"]
+        assert kwargs == {"forward_signals": False}
+        return 0
+
+    monkeypatch.setattr(run, "run_harbor", fake_run_harbor)
+
+    exit_code = run._run_harbor_with_live_export(
+        ["harbor", "run"],
+        sigil_exporter=FakeExporter(),
+    )
+
+    assert exit_code == 0
+    assert events == ["start", "harbor", "finish:succeeded:"]
+
+
 def test_finalize_job_dir_sanitizes_artifact_paths(monkeypatch, tmp_path) -> None:
     tasks_dir = tmp_path / "tasks"
     task_dir = tasks_dir / "promql-error-rate"
@@ -443,6 +470,71 @@ def test_cmd_job_rejects_agent_and_agent_import_path_together() -> None:
 
     with pytest.raises(SystemExit, match="Use either --agent or --agent-import-path"):
         cli._cmd_job(args)
+
+
+def test_cmd_job_passes_live_sigil_exporter_when_flag_enabled(monkeypatch) -> None:
+    monkeypatch.setattr(cli, "run_preflight", lambda *, quiet=False: None)
+
+    execute_calls: list[tuple[config.JobSpec, object]] = []
+    exporter_calls: list[tuple[object, object, object]] = []
+
+    def fake_execute_job(
+        spec: config.JobSpec,
+        *,
+        dry_run: bool = False,
+        quiet: bool = False,
+        sigil_exporter=None,
+    ):
+        execute_calls.append((spec, sigil_exporter))
+        return run.JobResult(
+            status="ran",
+            job_name=spec.job_name,
+            report_path=spec.jobs_dir / spec.job_name / "run_report.html",
+        )
+
+    def fake_live_exporter(job_dir, tasks_dir, options):
+        exporter_calls.append((job_dir, tasks_dir, options))
+        return "live-exporter"
+
+    monkeypatch.setattr(cli, "execute_job", fake_execute_job)
+    monkeypatch.setattr(cli, "SigilLiveExporter", fake_live_exporter)
+
+    args = argparse.Namespace(
+        model="openai/gpt-5.4-nano",
+        agent="opencode",
+        agent_import_path=config.DEFAULT_AGENT_IMPORT_PATH,
+        reasoning_effort="off",
+        jobs_dir=config.ROOT / "jobs",
+        job_name=None,
+        path=None,
+        n_attempts=1,
+        n_concurrent=1,
+        override_cpus=None,
+        override_memory_mb=None,
+        override_storage_mb=None,
+        task_name=["query-cpu-metrics"],
+        dry_run=False,
+        quiet=True,
+        sigil_experiment_export=True,
+        sigil_api="http://localhost:8080",
+        sigil_tenant="fake",
+        sigil_run_id="o11y-run-1",
+        sigil_name="o11y run",
+        sigil_description="",
+        sigil_tag=["o11y-bench", "opencode"],
+        sigil_sdk_path=None,
+    )
+
+    cli._cmd_job(args)
+
+    assert len(execute_calls) == 1
+    assert execute_calls[0][1] == "live-exporter"
+    assert len(exporter_calls) == 1
+    job_dir, tasks_dir, options = exporter_calls[0]
+    assert job_dir == config.ROOT / "jobs" / "openai-gpt-5-4-nano-off-opencode-k1"
+    assert tasks_dir == config.TASKS_DIR
+    assert options.run_id == "o11y-run-1"
+    assert options.tags == ["o11y-bench", "opencode"]
 
 
 def test_regrade_job_dir_updates_verifier_outputs(monkeypatch, tmp_path) -> None:

--- a/tests/test_sigil_export.py
+++ b/tests/test_sigil_export.py
@@ -138,7 +138,7 @@ def test_export_job_to_sigil_maps_trials_to_generations_and_scores(monkeypatch, 
     FakeClient.instances = []
     # Use the real SDK types (ExperimentRun/ScoreOutput/GenerationStart/...) but
     # swap the network-backed Client for a recorder fake.
-    monkeypatch.setattr(sigil_export, "_import_sdk", lambda sdk_path=None: sigil_sdk)
+    monkeypatch.setattr(sigil_export, "_import_sdk", lambda: sigil_sdk)
     monkeypatch.setattr(sigil_export, "_make_client", lambda sdk, options: FakeClient())
 
     job_dir, tasks_dir = _write_trial(tmp_path)

--- a/tests/test_sigil_export.py
+++ b/tests/test_sigil_export.py
@@ -4,9 +4,112 @@ import json
 from types import SimpleNamespace
 from typing import ClassVar
 
-import sigil_sdk
-
 from o11y_bench import sigil_export
+
+
+class FakeSdkObject(SimpleNamespace):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class FakeMessageRole:
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+class FakeExperimentRun:
+    def __init__(self, *, client, run_id, name, dataset, candidate, upload, agent_name):
+        self._client = client
+        self.run_id = run_id
+        self.name = name
+        self.dataset = dataset
+        self.candidate = candidate
+        self.upload = upload
+        self.agent_name = agent_name
+        self.accepted_scores = 0
+        self.produced_generation_ids = []
+
+    def reset_capture(self, *, conversation_id):
+        self.conversation_id = conversation_id
+
+    def start_generation(self, start):
+        start.tags = {**start.tags, "experiment.run_id": self.run_id}
+        start.metadata = {**start.metadata, "experiment_run_id": self.run_id}
+        return FakeExperimentRecorder(self, self._client.start_generation(start))
+
+    def add_scores(self, scores, *, item, generation_ids, trial_id):
+        generation_id = generation_ids[0] if generation_ids else ""
+        for score in scores:
+            score.run_id = self.run_id
+            score.generation_id = generation_id
+            score.source = SimpleNamespace(kind="experiment", id=self.run_id)
+            score.metadata = {
+                "dataset_id": self.dataset["id"],
+                "item_id": item.id,
+                "trial_id": trial_id,
+                **score.metadata,
+                "candidate": self.candidate,
+            }
+        result = self._client.export_scores(scores)
+        self.accepted_scores += result.accepted_count
+        self._client.flush()
+
+
+class FakeExperimentRecorder:
+    def __init__(self, run, recorder):
+        self.run = run
+        self.recorder = recorder
+
+    def __enter__(self):
+        return self.recorder.__enter__()
+
+    def __exit__(self, exc_type, exc, tb):
+        result = self.recorder.__exit__(exc_type, exc, tb)
+        self.run.produced_generation_ids = [self.recorder.last_generation.id]
+        return result
+
+
+class FakeSdk:
+    ConflictError = type("ConflictError", (Exception,), {})
+    MessageRole = FakeMessageRole
+    ExperimentRun = FakeExperimentRun
+    CreateExperimentRequest = FakeSdkObject
+    UpdateExperimentRequest = FakeSdkObject
+    ScoreOutput = FakeSdkObject
+    ScoreValue = FakeSdkObject
+    DatasetItem = FakeSdkObject
+    GenerationStart = FakeSdkObject
+    Generation = FakeSdkObject
+    ModelRef = FakeSdkObject
+    TokenUsage = FakeSdkObject
+    Message = FakeSdkObject
+    ToolCall = FakeSdkObject
+    ToolResult = FakeSdkObject
+
+    @staticmethod
+    def text_part(text):
+        return SimpleNamespace(type="text", text=text)
+
+    @staticmethod
+    def thinking_part(text):
+        return SimpleNamespace(type="thinking", text=text)
+
+    @staticmethod
+    def tool_call_part(tool_call):
+        return SimpleNamespace(type="tool_call", tool_call=tool_call)
+
+    @staticmethod
+    def tool_result_part(tool_result):
+        return SimpleNamespace(type="tool_result", tool_result=tool_result)
+
+    @staticmethod
+    def user_text_message(text):
+        return FakeSdkObject(role=FakeMessageRole.USER, parts=[FakeSdk.text_part(text)])
+
+    @staticmethod
+    def assistant_text_message(text):
+        return FakeSdkObject(role=FakeMessageRole.ASSISTANT, parts=[FakeSdk.text_part(text)])
 
 
 class FakeRecorder:
@@ -136,9 +239,8 @@ def _write_trial(tmp_path):
 
 def test_export_job_to_sigil_maps_trials_to_generations_and_scores(monkeypatch, tmp_path):
     FakeClient.instances = []
-    # Use the real SDK types (ExperimentRun/ScoreOutput/GenerationStart/...) but
-    # swap the network-backed Client for a recorder fake.
-    monkeypatch.setattr(sigil_export, "_import_sdk", lambda: sigil_sdk)
+    fake_sdk = FakeSdk()
+    monkeypatch.setattr(sigil_export, "_import_sdk", lambda: fake_sdk)
     monkeypatch.setattr(sigil_export, "_make_client", lambda sdk, options: FakeClient())
 
     job_dir, tasks_dir = _write_trial(tmp_path)

--- a/tests/test_sigil_export.py
+++ b/tests/test_sigil_export.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import ClassVar
+
+import sigil_sdk
+
+from o11y_bench import sigil_export
+
+
+class FakeRecorder:
+    """Stands in for the SDK GenerationRecorder.
+
+    ExperimentRun.produced_generation_ids reads ``last_generation.id`` after the
+    recorder context exits, so we surface the id the run assigned to the start.
+    """
+
+    def __init__(self, client, start):
+        self.client = client
+        self.start = start
+        self._result = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.client.generations.append((self.start, self._result))
+        return False
+
+    def set_result(self, generation):
+        self._result = generation
+
+    @property
+    def last_generation(self):
+        return SimpleNamespace(id=self.start.id)
+
+
+class FakeClient:
+    """Records the control-plane + score-export calls the exporter makes.
+
+    Implements the surface ExperimentRun and the exporter use, so the real SDK
+    ExperimentRun/ScoreOutput/GenerationStart types drive the mapping without
+    touching the network.
+    """
+
+    instances: ClassVar[list[FakeClient]] = []
+
+    def __init__(self):
+        self.experiments = []
+        self.generations = []
+        self.scores = []
+        self.completed = []
+        self.flushed = False
+        self.closed = False
+        FakeClient.instances.append(self)
+
+    def create_experiment(self, request):
+        self.experiments.append(request)
+
+    def update_experiment(self, run_id, request):
+        self.experiments.append((run_id, request))
+
+    def start_generation(self, start):
+        return FakeRecorder(self, start)
+
+    def flush(self):
+        self.flushed = True
+
+    def export_scores(self, scores):
+        self.scores.extend(scores)
+        return SimpleNamespace(accepted_count=len(scores))
+
+    def complete_experiment(self, run_id, **kwargs):
+        self.completed.append((run_id, kwargs))
+
+    def experiment_url(self, run_id):
+        return f"https://sigil.example/a/grafana-sigil-app/evaluation/experiments/{run_id}"
+
+    def shutdown(self):
+        self.closed = True
+
+
+def _write_trial(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    task_dir = tasks_dir / "query-cpu-metrics"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('[metadata]\ncategory = "prometheus_query"\n')
+
+    job_dir = tmp_path / "jobs" / "openai-gpt-5-4-nano-off-k1"
+    trial_dir = job_dir / "query-cpu-metrics__abc123"
+    agent_dir = trial_dir / "agent"
+    verifier_dir = trial_dir / "verifier"
+    agent_dir.mkdir(parents=True)
+    verifier_dir.mkdir()
+    (agent_dir / "transcript.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "user", "message": "Find CPU usage"}),
+                json.dumps(
+                    {
+                        "type": "assistant",
+                        "message": {"content": [{"type": "text", "text": "CPU is high on api-1"}]},
+                    }
+                ),
+            ]
+        )
+        + "\n"
+    )
+    (verifier_dir / "grading_details.json").write_text(
+        json.dumps({"score": 1.0, "explanation:rubric": "accurate"})
+    )
+    (trial_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "agent_info": {"model_info": {"provider": "openai", "name": "openai/gpt-5.4-nano"}},
+                "agent_result": {
+                    "n_input_tokens": 10,
+                    "n_cache_tokens": 2,
+                    "n_output_tokens": 5,
+                    "cost_usd": 0.001,
+                    "metadata": {"reasoning_effort": "off"},
+                },
+                "agent_execution": {
+                    "started_at": "2026-05-20T00:00:00Z",
+                    "finished_at": "2026-05-20T00:00:12Z",
+                },
+                "task_name": "query-cpu-metrics",
+                "task_checksum": "checksum-1",
+                "verifier_result": {"rewards": {"reward": 1.0}},
+            }
+        )
+    )
+    return job_dir, tasks_dir
+
+
+def test_export_job_to_sigil_maps_trials_to_generations_and_scores(monkeypatch, tmp_path):
+    FakeClient.instances = []
+    # Use the real SDK types (ExperimentRun/ScoreOutput/GenerationStart/...) but
+    # swap the network-backed Client for a recorder fake.
+    monkeypatch.setattr(sigil_export, "_import_sdk", lambda sdk_path=None: sigil_sdk)
+    monkeypatch.setattr(sigil_export, "_make_client", lambda sdk, options: FakeClient())
+
+    job_dir, tasks_dir = _write_trial(tmp_path)
+
+    result = sigil_export.export_job_to_sigil(
+        job_dir,
+        tasks_dir,
+        sigil_export.SigilExportOptions(run_id="o11y-run-1", tags=["candidate"]),
+    )
+
+    assert result.run_id == "o11y-run-1"
+    assert result.generation_count == 1
+    assert result.score_count == 1
+    assert "o11y-run-1" in result.url
+
+    client = FakeClient.instances[0]
+    assert client.flushed is True
+    assert client.closed is True
+    assert client.experiments[0].tags == ["o11y-bench", "candidate"]
+
+    # one generation, tagged with the experiment run_id + o11y-bench labels
+    assert len(client.generations) == 1
+    start, _generation = client.generations[0]
+    assert start.conversation_title == "query-cpu-metrics"
+    assert start.tags["experiment.run_id"] == "o11y-run-1"
+    assert start.tags["task_id"] == "query-cpu-metrics"
+    assert start.metadata["experiment_run_id"] == "o11y-run-1"
+
+    # one score, attributed to the run + generation, with grouping metadata
+    assert len(client.scores) == 1
+    score = client.scores[0]
+    assert score.run_id == "o11y-run-1"
+    assert score.generation_id == _generation.id
+    assert score.value.number == 1.0
+    assert score.passed is True
+    assert score.source.kind == "experiment"
+    assert score.metadata["dataset_id"] == "o11y-bench"
+    assert score.metadata["item_id"] == "query-cpu-metrics"
+    assert score.metadata["trial_id"] == "query-cpu-metrics__abc123"
+    assert score.metadata["task_id"] == "query-cpu-metrics"
+    assert score.metadata["task_category"] == "prometheus_query"
+    assert score.metadata["total_tokens"] == 17
+    assert score.metadata["candidate"] == {"job_name": "openai-gpt-5-4-nano-off-k1"}
+    assert score.explanation == "accurate"
+
+    assert client.completed == [
+        (
+            "o11y-run-1",
+            {
+                "status": "succeeded",
+                "score_count": 1,
+                "error": "",
+                "metadata": {
+                    "source": "o11y-bench",
+                    "job_name": "openai-gpt-5-4-nano-off-k1",
+                    "exported_generations": 1,
+                    "exported_scores": 1,
+                },
+            },
+        )
+    ]
+
+
+def test_default_run_id_is_stable(tmp_path):
+    job_dir = tmp_path / "jobs" / "demo"
+    job_dir.mkdir(parents=True)
+
+    first = sigil_export._default_run_id(job_dir)
+    second = sigil_export._default_run_id(job_dir)
+
+    assert first == second
+    assert first.startswith("o11y-bench-demo-")

--- a/uv.lock
+++ b/uv.lock
@@ -480,6 +480,39 @@ http = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1060,6 +1093,11 @@ dependencies = [
     { name = "pyyaml" },
 ]
 
+[package.optional-dependencies]
+sigil = [
+    { name = "sigil-sdk" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -1077,7 +1115,9 @@ requires-dist = [
     { name = "promql-parser", specifier = ">=0.7.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "sigil-sdk", marker = "extra == 'sigil'", editable = "../sigil-sdk/python" },
 ]
+provides-extras = ["sigil"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1105,6 +1145,105 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/2b/28ba5b128f47fe8c3bab541000d6feb4b5a9bd26623ca013406f01c0fb60/opentelemetry_exporter_otlp_proto_grpc-1.42.1-py3-none-any.whl", hash = "sha256:0ae1177e2038b18a929b3098215243631ef91136cba26b7e2b12790ceb7e87cc", size = 19617, upload-time = "2026-05-21T16:32:34.278Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/9d/171c02c84a76940b7e601805b3bb536985aded9168fbcc9ba52f0a730fa2/opentelemetry_proto-1.42.1-py3-none-any.whl", hash = "sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c", size = 71782, upload-time = "2026-05-21T16:32:44.867Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
 ]
 
 [[package]]
@@ -1251,6 +1390,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1679,6 +1833,34 @@ sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff958562
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
 ]
+
+[[package]]
+name = "sigil-sdk"
+version = "0.7.0"
+source = { editable = "../sigil-sdk/python" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "grpcio", specifier = ">=1.80.0" },
+    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.80.0" },
+    { name = "opentelemetry-api", specifier = ">=1.27.0" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.27.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0" },
+    { name = "opentelemetry-proto", specifier = ">=1.27.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
+    { name = "protobuf", specifier = ">=6.31.1" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "six"

--- a/uv.lock
+++ b/uv.lock
@@ -1115,7 +1115,7 @@ requires-dist = [
     { name = "promql-parser", specifier = ">=0.7.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "sigil-sdk", marker = "extra == 'sigil'", editable = "../sigil-sdk/python" },
+    { name = "sigil-sdk", marker = "extra == 'sigil'", specifier = "==0.8.0" },
 ]
 provides-extras = ["sigil"]
 
@@ -1836,8 +1836,8 @@ wheels = [
 
 [[package]]
 name = "sigil-sdk"
-version = "0.7.0"
-source = { editable = "../sigil-sdk/python" }
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
     { name = "opentelemetry-api" },
@@ -1847,20 +1847,10 @@ dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "protobuf" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "grpcio", specifier = ">=1.80.0" },
-    { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.80.0" },
-    { name = "opentelemetry-api", specifier = ">=1.27.0" },
-    { name = "opentelemetry-exporter-otlp-proto-grpc", specifier = ">=1.27.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.27.0" },
-    { name = "opentelemetry-proto", specifier = ">=1.27.0" },
-    { name = "opentelemetry-sdk", specifier = ">=1.27.0" },
-    { name = "protobuf", specifier = ">=6.31.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/ca/97/d4108386cdf1cb95cae51cc11fa0278d28352fb2b9211eddc8ceaec34292/sigil_sdk-0.8.0.tar.gz", hash = "sha256:f1457c2f1837267f370c1a1927e1668395331d8d3f8cab47e38f648021cb422e", size = 135249, upload-time = "2026-06-01T21:08:31.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/7b/5fbdb75864f2cf4cba98b5e9d7d8d279426bc690716dd920fdbb2f6b01cf/sigil_sdk-0.8.0-py3-none-any.whl", hash = "sha256:9be9ba3b3a764587656a3ab5d20b99a2229ac3e1c7bd74cdfa79d9c65468ec0e", size = 88603, upload-time = "2026-06-01T21:08:30.622Z" },
 ]
-provides-extras = ["dev"]
 
 [[package]]
 name = "six"


### PR DESCRIPTION
## Notes

This PR enables optional experiment tracking within the Grafana AI o11y Experiments API (Sigil). The goal is to help track, share, and improve o11y bench results over time, for instance by improving an agent harness or local model performance. 

This is completely opt-in and results are not exported or shared unless the user runs the additional set up step to install dependencies:

```
mise run sigil:setup
```

A sample `.env.sample` has been included showing the required information for publishing results to Sigil. Here is a sample command of how to run it over one task for a smoke test to ensure results are published:

```
➜  o11y-bench git:(jgordley/sigil-o11y-bench-support) ✗ mise run bench:job -- \
  --model openai/gpt-5.5 \
  --task-name promql-highest-backend-error-ratio \
  --sigil-experiment-export \
  --sigil-name "Experiment: o11y-bench-10-task-attempt-dev-2" \
  --sigil-description "Testing out gpt 5.5 on a few o11y bench tasks" \
  --sigil-tag model:openai/gpt-5.5 \
  --sigil-tag run:smoke
```
The output will provide a link to where the Experiment will be in the portal:
```
Exported 10 generation(s), 10 score(s) to Sigil run o11y-bench-openai-gpt-5-5-off-k1-a4c6bbe820

View in Sigil: https://samplestack.grafana.net/a/grafana-sigil-app/evaluation/experiments/o11y-bench-openai-gpt-5-5-off-k1-a4c6bbe820
```

## Testing

Single test run results with 10 tasks:

<img width="2533" height="1252" alt="o11y-bench-single-run" src="https://github.com/user-attachments/assets/db0f511c-b456-4823-8238-59b353479c94" />

Comparing two runs:

<img width="2557" height="1275" alt="Screenshot 2026-06-01 at 9 00 00 PM" src="https://github.com/user-attachments/assets/d1ef4c09-31d2-4f20-933f-ef127e53544f" />
