### PR TITLE
enhancement: update run report to show per-step token and cost, and update timestamp header

### DIFF
--- a/reporting/report_template.html
+++ b/reporting/report_template.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>o11y-bench — {model_display} — {job_timestamp}</title>
+  <title>o11y-bench — {model_display} — {job_name}</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
     pre {{ white-space: pre-wrap; word-break: break-word; }}
@@ -40,6 +40,7 @@
       <div class="mt-2 text-sm text-gray-500 space-y-0.5">
         <p><strong>Model:</strong> {model_display}</p>
         <p><strong>Job:</strong> <code class="bg-gray-100 px-1 rounded font-mono text-xs">{job_id}</code></p>
+        <p><strong>Job name:</strong> {job_name}</p>
         <p><strong>Timestamp:</strong> {job_timestamp}</p>
         <p><strong>Shots per task:</strong> {shots_per_task}</p>
       </div>

--- a/reporting/run_report.py
+++ b/reporting/run_report.py
@@ -155,7 +155,20 @@ def render_transcript(messages: list[JsonDict]) -> str:
                 content_blocks = [{"type": "text", "text": raw}]
 
             agent_parts = ['<div class="pl-3 border-l-2 border-green-300 mb-2">']
-            agent_parts.append('<span class="font-medium text-green-700 text-xs">Agent:</span>')
+            metrics = msg.get("metrics")
+            metrics_html = ""
+            if metrics:
+                tok_in = metrics.get("prompt_tokens", 0)
+                tok_out = metrics.get("completion_tokens", 0)
+                cost = metrics.get("cost_usd")
+                cost_str = f" · ${cost:.4f}" if cost else ""
+                metrics_html = (
+                    f' <span class="text-[10px] text-gray-400 font-normal">'
+                    f"{tok_in:,} in / {tok_out:,} out{cost_str}</span>"
+                )
+            agent_parts.append(
+                f'<span class="font-medium text-green-700 text-xs">Agent:</span>{metrics_html}'
+            )
 
             for block in content_blocks:
                 if not isinstance(block, dict):
@@ -295,7 +308,14 @@ def _load_atif_trajectory(path: Path) -> list[JsonDict]:
                         "input": tc.get("arguments", {}),
                     }
                 )
-            messages.append({"type": "assistant", "message": {"content": content_blocks}})
+            step_metrics = step.get("metrics")
+            messages.append(
+                {
+                    "type": "assistant",
+                    "message": {"content": content_blocks},
+                    **({"metrics": step_metrics} if step_metrics else {}),
+                }
+            )
             if observation and "results" in observation:
                 for result in observation["results"]:
                     messages.append(
@@ -457,7 +477,13 @@ def generate_report(job_dir: Path, tasks_dir: Path | None = None) -> str:
     first_result = trials[0]["result"]
     model_display = trial_model_display(first_result, trials[0]["result_path"].resolve())
     job_id = first_result.get("config", {}).get("job_id", job_dir.name)
-    job_timestamp = job_dir.name
+    job_result_path = job_dir / "result.json"
+    if job_result_path.exists():
+        with open(job_result_path) as f:
+            job_result = json.load(f)
+        job_timestamp = job_result.get("started_at", job_dir.name)
+    else:
+        job_timestamp = job_dir.name
 
     # Group trials by task_name (for multi-shot)
     tasks: dict[str, list[JsonDict]] = {}
@@ -702,6 +728,7 @@ def generate_report(job_dir: Path, tasks_dir: Path | None = None) -> str:
     return template.format(
         model_display=escape_html(model_display),
         job_id=escape_html(job_id),
+        job_name=escape_html(job_dir.name),
         job_timestamp=escape_html(job_timestamp),
         shots_per_task=shots_per_task,
         k_label_title=escape_html(k_label.title()),


### PR DESCRIPTION
add token in/out and cost to each step in the report html files

<img width="407" height="467" alt="Screenshot 2026-06-04 at 13 27 51" src="https://github.com/user-attachments/assets/3ebcf9ff-097f-4cc5-90bd-fcfcf19dd5c1" />


fix the `timestamp` header to show an actual timestamp, and add a `job name` header 
<img width="366" height="185" alt="Screenshot 2026-06-04 at 13 28 19" src="https://github.com/user-attachments/assets/9338e37d-4c32-43ac-b253-f81bdf94faa5" />
