### PR TITLE
feat(agento11y): add Grafana agento11y exporting option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,30 @@
+# Provider credentials used by the benchmark and its verifier.
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+GEMINI_API_KEY=
+OPENROUTER_API_KEY=
+
+# Agent Observability ingest plane: experiment lifecycle, trials, generations, and scores.
+AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
+AGENTO11Y_PROTOCOL=http
+AGENTO11Y_AUTH_MODE=basic
+AGENTO11Y_AUTH_TENANT_ID=
+AGENTO11Y_AUTH_TOKEN=
+AGENTO11Y_INGEST_ACTOR=o11y-bench
+
+# Agent Observability control plane: stored test-suite synchronization and retrieval.
+AGENTO11Y_CONTROL_ENDPOINT=https://<stack>.grafana.net/a/grafana-sigil-app
+AGENTO11Y_GRAFANA_URL=https://<stack>.grafana.net
+AGENTO11Y_SERVICE_ACCOUNT_TOKEN=
+AGENTO11Y_SUITE_ID=o11y-bench
+AGENTO11Y_SUITE_VERSION=latest_published
+
+# Optional experiment labeling. AGENTO11Y_EXPERIMENT_ID should be unset for
+# suite runs unless each process receives a unique value.
+AGENTO11Y_EXPERIMENT_ID=
+AGENTO11Y_EXPERIMENT_NAME=
+AGENTO11Y_EXPERIMENT_DESCRIPTION=
+AGENTO11Y_EXPERIMENT_TAGS=
+AGENTO11Y_AGENT_NAME=o11y-bench
+AGENTO11Y_AGENT_VERSION=dev

--- a/.env.sample
+++ b/.env.sample
@@ -6,7 +6,7 @@ GEMINI_API_KEY=
 OPENROUTER_API_KEY=
 
 # Agent Observability ingest plane: experiment lifecycle, trials, generations, and scores.
-AGENTO11Y_ENDPOINT=https://sigil-prod-<region>.grafana.net
+AGENTO11Y_ENDPOINT=https://agento11y-prod-<region>.grafana.net
 AGENTO11Y_PROTOCOL=http
 AGENTO11Y_AUTH_MODE=basic
 AGENTO11Y_AUTH_TENANT_ID=
@@ -14,7 +14,7 @@ AGENTO11Y_AUTH_TOKEN=
 AGENTO11Y_INGEST_ACTOR=o11y-bench
 
 # Agent Observability control plane: stored test-suite synchronization and retrieval.
-AGENTO11Y_CONTROL_ENDPOINT=https://<stack>.grafana.net/a/grafana-sigil-app
+AGENTO11Y_CONTROL_ENDPOINT=https://<stack>.grafana.net/a/grafana-agento11y-app
 AGENTO11Y_GRAFANA_URL=https://<stack>.grafana.net
 AGENTO11Y_SERVICE_ACCOUNT_TOKEN=
 AGENTO11Y_SUITE_ID=o11y-bench

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ build/
 .venv/
 venv/
 .env
+.env.*
+!.env.sample
 .ruff_cache/
 .pytest_cache/
 .mypy_cache/

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ The integration uses two credential planes:
 | `AGENTO11Y_ENDPOINT` | Experiment, trial, generation, and score ingest URL | Grafana Cloud **Agent Observability > Configuration > Connection** |
 | `AGENTO11Y_AUTH_TENANT_ID` | Grafana Cloud stack/tenant ID used for ingest basic auth | Agent Observability connection details |
 | `AGENTO11Y_AUTH_TOKEN` | Access policy token with `sigil:write` for ingest | Agent Observability connection details |
-| `AGENTO11Y_CONTROL_ENDPOINT` | Grafana app URL used to publish and retrieve test suites | `https://<stack>.grafana.net/a/grafana-sigil-app` |
+| `AGENTO11Y_CONTROL_ENDPOINT` | Grafana app URL used to publish and retrieve test suites | `https://<stack>.grafana.net/a/grafana-agento11y-app` |
 | `AGENTO11Y_SERVICE_ACCOUNT_TOKEN` | Grafana service-account token used by test-suite APIs | Grafana **Administration > Users and access > Service accounts** |
 | `AGENTO11Y_INGEST_ACTOR` | Tenant or owner label attached to published experiments | Choose a stable identifier for the publishing team or user |
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - [Running A Single Job](#running-a-single-job)
 - [Running With Different Agents](#running-with-different-agents)
 - [Running Your Own Models](#running-your-own-models)
+- [Publishing Results To Agent Observability](#publishing-results-to-agent-observability)
 - [Submitting Results To The Leaderboard](#submitting-results-to-the-leaderboard)
 
 ---
@@ -331,6 +332,86 @@ The suite uses the default repo agent.
 If you want to benchmark a custom agent across the same matrix, run `bench:job` variants yourself
 or extend suite orchestration in code.
 
+## Publishing Results To Agent Observability
+
+Publishing is optional. Harbor remains the experiment runner and ATIF remains the native trajectory
+format. The integration sends experiment and trial lifecycle events, candidate generations,
+token usage and cost, verifier scores, and links to Harbor trajectory and grading artifacts.
+Each scored trial is sent as soon as Harbor finishes it rather than waiting for the full job.
+
+Install the published `agento11y` package through the optional project extra:
+
+```bash
+mise run agento11y:setup
+```
+
+### Configure Agent Observability
+
+Copy `.env.sample` to `.env` and fill in the `AGENTO11Y_*` values. Mise loads `.env` automatically.
+Do not commit that file.
+
+The integration uses two credential planes:
+
+| Variable | Purpose | Where to find it |
+|---|---|---|
+| `AGENTO11Y_ENDPOINT` | Experiment, trial, generation, and score ingest URL | Grafana Cloud **Agent Observability > Configuration > Connection** |
+| `AGENTO11Y_AUTH_TENANT_ID` | Grafana Cloud stack/tenant ID used for ingest basic auth | Agent Observability connection details |
+| `AGENTO11Y_AUTH_TOKEN` | Access policy token with `sigil:write` for ingest | Agent Observability connection details |
+| `AGENTO11Y_CONTROL_ENDPOINT` | Grafana app URL used to publish and retrieve test suites | `https://<stack>.grafana.net/a/grafana-sigil-app` |
+| `AGENTO11Y_SERVICE_ACCOUNT_TOKEN` | Grafana service-account token used by test-suite APIs | Grafana **Administration > Users and access > Service accounts** |
+| `AGENTO11Y_INGEST_ACTOR` | Tenant or owner label attached to published experiments | Choose a stable identifier for the publishing team or user |
+
+`AGENTO11Y_SUITE_ID` selects the remote test-suite name and defaults to `o11y-bench`.
+`AGENTO11Y_AGENT_NAME`, `AGENTO11Y_AGENT_VERSION`, `AGENTO11Y_EXPERIMENT_NAME`,
+`AGENTO11Y_EXPERIMENT_DESCRIPTION`, and `AGENTO11Y_EXPERIMENT_TAGS` customize run labels.
+See [.env.sample](.env.sample) for the complete configuration.
+
+### Publish The Dataset
+
+The YAML files under `tasks-spec/` remain the only source of truth for the dataset. Publish them to
+Agent Observability before sending benchmark results:
+
+```bash
+mise run agento11y:sync-suite
+```
+
+The task validates every YAML spec, converts it to an Agent Observability test case, synchronizes the
+configured `AGENTO11Y_SUITE_ID`, removes remote cases no longer present in YAML, and publishes the
+new suite version. It prints progress and a direct test-suite link. Running it again with unchanged
+YAML is idempotent.
+
+Choose a different remote suite name without changing the source dataset:
+
+```bash
+AGENTO11Y_SUITE_ID=o11y-bench-my-team mise run agento11y:sync-suite
+```
+
+### Publish Benchmark Results
+
+Run a job through the Agent Observability mise task:
+
+```bash
+mise run agento11y:job -- \
+  --model anthropic/claude-haiku-4-5-20251001 \
+  --task-name promql-error-rate \
+  --n-attempts 3
+```
+
+This task installs the published SDK extra for the command and supplies the explicit
+`--agento11y-publish` opt-in flag. The equivalent direct command is:
+
+```bash
+uv run --extra agento11y python -m o11y_bench job \
+  --model anthropic/claude-haiku-4-5-20251001 \
+  --task-name promql-error-rate \
+  --n-attempts 3 \
+  --agento11y-publish
+```
+
+Use `mise run agento11y:suite -- <options>` to publish the standard multi-model suite. Publishing
+state is retained in each job directory, so resume and retry operations preserve stable experiment,
+trial, and attempt identities instead of duplicating completed results.
+
 ## Reports And Artifacts
 
 Single-job report:
@@ -413,6 +494,8 @@ the full submission structure, validation rules, and example layout.
 mise run setup:sync
 mise run setup:preflight
 mise run setup:smoke
+mise run agento11y:setup
+mise run agento11y:sync-suite
 mise run lint
 mise run format
 mise run typecheck

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,8 @@
 min_version = "2024.1.0"
 
+[env]
+_.file = ".env"
+
 [tools]
 python = "3.14"
 uv = "0.11.8"
@@ -13,6 +16,24 @@ run = "uv run python -m scripts.sync_tasks"
 [tasks."setup:preflight"]
 description = "Clean stale Harbor Docker projects and pre-build shared images"
 run = "bash scripts/harbor_preflight.sh"
+
+[tasks."agento11y:setup"]
+description = "Install the published Agent Observability SDK integration"
+run = "uv sync --extra agento11y"
+
+[tasks."agento11y:sync-suite"]
+description = "Synchronize and publish tasks-spec YAML as an Agent Observability test suite"
+run = "uv run --extra agento11y python -m o11y_bench.agento11y_suite"
+
+[tasks."agento11y:job"]
+description = "Run or resume one benchmark variant and publish it to Agent Observability"
+depends = ["setup:sync"]
+run = "uv run --extra agento11y python -m o11y_bench job --agento11y-publish"
+
+[tasks."agento11y:suite"]
+description = "Run the standard suite and publish it to Agent Observability"
+depends = ["setup:sync"]
+run = "uv run --extra agento11y python -m o11y_bench suite --agento11y-publish"
 
 # -- Bench --
 

--- a/o11y_bench/agento11y_publish.py
+++ b/o11y_bench/agento11y_publish.py
@@ -1,0 +1,526 @@
+"""Stream completed Harbor trials to Agent Observability experiments."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from grading.transcript_parser import parse_transcript
+from reporting.report_data import (
+    agent_result_metrics,
+    agent_seconds,
+    load_trials,
+    reward_counts_as_pass,
+    trial_reasoning_effort,
+)
+
+from .agento11y_suite import DEFAULT_SUITE_ID
+
+_STATE_FILE = ".agento11y-publish.json"
+
+
+@dataclass(slots=True)
+class Agento11yPublishOptions:
+    """Environment-driven settings for one benchmark experiment."""
+
+    experiment_id: str = ""
+    suite_id: str = DEFAULT_SUITE_ID
+    suite_version: str = "latest_published"
+    name: str = ""
+    description: str = ""
+    tags: list[str] = field(default_factory=lambda: ["o11y-bench"])
+
+    @classmethod
+    def from_env(cls) -> Agento11yPublishOptions:
+        raw_tags = os.getenv("AGENTO11Y_EXPERIMENT_TAGS", "")
+        tags = [tag.strip() for tag in raw_tags.split(",") if tag.strip()]
+        return cls(
+            experiment_id=os.getenv("AGENTO11Y_EXPERIMENT_ID", "").strip(),
+            suite_id=os.getenv("AGENTO11Y_SUITE_ID", DEFAULT_SUITE_ID).strip() or DEFAULT_SUITE_ID,
+            suite_version=os.getenv("AGENTO11Y_SUITE_VERSION", "latest_published").strip()
+            or "latest_published",
+            name=os.getenv("AGENTO11Y_EXPERIMENT_NAME", "").strip(),
+            description=os.getenv("AGENTO11Y_EXPERIMENT_DESCRIPTION", "").strip(),
+            tags=["o11y-bench", *tags],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Agento11yPublishResult:
+    experiment_id: str
+    trial_count: int
+    score_count: int
+    url: str
+
+
+class Agento11yLivePublisher:
+    """Publish each scored Harbor trial as soon as its result artifact appears."""
+
+    def __init__(
+        self,
+        job_dir: Path,
+        tasks_dir: Path,
+        *,
+        model: str,
+        agent_name: str,
+        agent_version: str,
+        options: Agento11yPublishOptions | None = None,
+        planned_trial_count: int | None = None,
+        poll_interval_seconds: float = 1.0,
+    ) -> None:
+        self.job_dir = job_dir.resolve()
+        self.tasks_dir = tasks_dir.resolve()
+        self.model = model
+        self.agent_name = agent_name
+        self.agent_version = agent_version
+        self.options = options or Agento11yPublishOptions.from_env()
+        self.planned_trial_count = planned_trial_count
+        self.poll_interval_seconds = poll_interval_seconds
+        self.experiment_id = self.options.experiment_id or _default_experiment_id(self.job_dir)
+        self._sdk: Any | None = None
+        self._experiments: Any | None = None
+        self._experiment: Any | None = None
+        self._suite_cases: dict[str, Any] = {}
+        self._exported: set[str] = set()
+        self._attempts: dict[str, int] = {}
+        self._trial_count = 0
+        self._score_count = 0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._scan_lock = threading.Lock()
+        self._error: Exception | None = None
+        self.last_result: Agento11yPublishResult | None = None
+        self._load_state()
+
+    @property
+    def url(self) -> str:
+        if self._experiment is not None:
+            return str(self._experiment.url)
+        base = os.getenv("AGENTO11Y_GRAFANA_URL", "").rstrip("/")
+        return f"{base}/a/grafana-sigil-app/experiments/runs/{self.experiment_id}"
+
+    def start(self) -> None:
+        self._connect()
+        self._thread = threading.Thread(
+            target=self._poll_loop,
+            name="agento11y-live-publish",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def finish(self, *, succeeded: bool, error: str = "") -> Agento11yPublishResult:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=max(5.0, self.poll_interval_seconds * 3))
+
+        publish_error = self._error
+        try:
+            self.scan_once()
+        except Exception as exc:
+            publish_error = publish_error or exc
+
+        failure: RuntimeError | None = None
+        if publish_error is not None:
+            failure = RuntimeError(f"Agent Observability live publishing failed: {publish_error}")
+        elif not succeeded:
+            failure = RuntimeError(error or "Harbor benchmark failed")
+
+        result_url = self.url
+        if self._experiment is not None:
+            if failure is None:
+                self._experiment.__exit__(None, None, None)
+            else:
+                self._experiment.__exit__(RuntimeError, failure, None)
+        self.last_result = Agento11yPublishResult(
+            experiment_id=self.experiment_id,
+            trial_count=self._trial_count,
+            score_count=self._score_count,
+            url=result_url,
+        )
+        if publish_error is not None:
+            assert failure is not None
+            raise failure from publish_error
+        return self.last_result
+
+    def publish_existing(self) -> Agento11yPublishResult:
+        self._connect()
+        self.scan_once()
+        return self.finish(succeeded=True)
+
+    def scan_once(self) -> None:
+        if self._experiment is None or not self.job_dir.exists():
+            return
+        with self._scan_lock:
+            for result in load_trials(self.job_dir):
+                result_path = Path(str(result["__result_path"]))
+                trial_dir = result_path.parent
+                harbor_trial_id = trial_dir.name
+                rewards = (result.get("verifier_result") or {}).get("rewards") or {}
+                if harbor_trial_id in self._exported or rewards.get("reward") is None:
+                    continue
+                self._publish_trial(result, trial_dir, rewards)
+                self._exported.add(harbor_trial_id)
+                self._trial_count += 1
+                self._save_state()
+
+    def _connect(self) -> None:
+        if self._experiment is not None:
+            return
+        sdk, experiments = _import_agento11y()
+        provider, model_name = _model_ref(self.model)
+        experiment = experiments.experiment_from_suite(
+            self.options.suite_id,
+            version=self.options.suite_version,
+            name=self.options.name or f"o11y-bench {self.job_dir.name}",
+            experiment_id=self.experiment_id,
+            candidate={
+                "agent_name": self.agent_name,
+                "agent_version": self.agent_version,
+                "model_provider": provider,
+                "model_name": model_name,
+            },
+            description=self.options.description,
+            tags=_dedupe(
+                [*self.options.tags, provider, model_name, trial_reasoning_label(self.model)]
+            ),
+            planned_trial_count=self.planned_trial_count,
+            metadata={
+                "source": "o11y-bench",
+                "job_name": self.job_dir.name,
+                "framework": "harbor",
+                "transcript_format": "ATIF",
+            },
+        )
+        experiment.__enter__()
+        self._sdk = sdk
+        self._experiments = experiments
+        self._experiment = experiment
+        self._suite_cases = {case.test_case_id: case for case in experiment.suite.cases}
+
+    def _poll_loop(self) -> None:
+        while not self._stop.wait(self.poll_interval_seconds):
+            try:
+                self.scan_once()
+            except Exception as exc:
+                self._error = exc
+                self._stop.set()
+
+    def _publish_trial(
+        self,
+        result: dict[str, Any],
+        trial_dir: Path,
+        rewards: dict[str, Any],
+    ) -> None:
+        assert self._sdk is not None
+        assert self._experiments is not None
+        assert self._experiment is not None
+        task_id = str(result.get("task_name") or trial_dir.name.split("__", 1)[0])
+        case = self._suite_cases.get(task_id)
+        if case is None:
+            raise ValueError(f"Harbor result references task {task_id!r}, absent from stored suite")
+        attempt = self._attempt_for(task_id, trial_dir.name)
+        cost, input_tokens, cache_tokens, output_tokens = agent_result_metrics(result)
+        provider, model_name = _result_model_ref(result, self.model)
+        conversation_id = self._experiments.stable_id("conv", self.experiment_id, task_id, attempt)
+        generation_id = self._experiments.stable_id("gen", self.experiment_id, task_id, attempt)
+        final_output = _final_output(trial_dir)
+        usage = self._sdk.TokenUsage(
+            input_tokens=input_tokens,
+            cache_read_input_tokens=cache_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + cache_tokens + output_tokens,
+        )
+        self._experiment.client.record_generation(
+            generation_id,
+            conversation_id=conversation_id,
+            input_text=str(case.input),
+            output_text=final_output,
+            model_provider=provider,
+            model_name=model_name,
+            agent_name=self.agent_name,
+            agent_version=self.agent_version,
+            operation_name="harbor-trial",
+            usage=usage,
+            tags={
+                "experiment.run_id": self.experiment_id,
+                "task_id": task_id,
+                "task_category": case.category,
+            },
+            metadata={
+                "source": "o11y-bench",
+                "harbor_trial_id": trial_dir.name,
+                "reasoning_effort": trial_reasoning_effort(result),
+            },
+        )
+        self._experiment.client.flush_generations()
+
+        version = str(result.get("task_checksum") or "unknown")
+        score_specs = _score_specs(result, trial_dir, rewards, version)
+        with self._experiment.trial(
+            case,
+            attempt=attempt,
+            metadata={
+                "source": "o11y-bench",
+                "harbor_trial_id": trial_dir.name,
+                "reasoning_effort": trial_reasoning_effort(result),
+            },
+        ) as trial:
+            trial.bind_generation(generation_id, conversation_id=conversation_id)
+            trial.set_usage(
+                cost=cost if cost > 0 else None,
+            )
+            for score in score_specs:
+                trial.record_evaluation(score)
+                self._score_count += trial.flush()
+            for name, path in _artifact_paths(trial_dir):
+                trial.artifact(name, path=str(path))
+
+        duration_ms = max(0, int(agent_seconds(result) * 1000))
+        self._experiment.client.update_trial(
+            self.experiment_id,
+            trial.trial_id,
+            status="completed",
+            duration_ms=duration_ms,
+            conversation_id=conversation_id,
+            cost=cost if cost > 0 else None,
+        )
+
+    def _attempt_for(self, task_id: str, harbor_trial_id: str) -> int:
+        key = f"{task_id}\x1f{harbor_trial_id}"
+        existing = self._attempts.get(key)
+        if existing is not None:
+            return existing
+        used = [
+            attempt
+            for stored, attempt in self._attempts.items()
+            if stored.startswith(f"{task_id}\x1f")
+        ]
+        attempt = max(used, default=0) + 1
+        self._attempts[key] = attempt
+        self._save_state()
+        return attempt
+
+    def _load_state(self) -> None:
+        path = self.job_dir / _STATE_FILE
+        try:
+            payload = json.loads(path.read_text())
+        except OSError, json.JSONDecodeError:
+            return
+        if payload.get("experiment_id") != self.experiment_id:
+            return
+        self._exported = {str(item) for item in payload.get("exported_trials", [])}
+        self._attempts = {
+            str(key): int(value) for key, value in (payload.get("attempts") or {}).items()
+        }
+        self._trial_count = len(self._exported)
+        self._score_count = int(payload.get("score_count") or 0)
+
+    def _save_state(self) -> None:
+        if not self.job_dir.exists():
+            return
+        payload = {
+            "experiment_id": self.experiment_id,
+            "exported_trials": sorted(self._exported),
+            "attempts": self._attempts,
+            "score_count": self._score_count,
+        }
+        (self.job_dir / _STATE_FILE).write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _score_specs(
+    result: dict[str, Any],
+    trial_dir: Path,
+    rewards: dict[str, Any],
+    version: str,
+) -> list[Any]:
+    _, experiments = _import_agento11y()
+    details = _grading_details(trial_dir)
+    check_names, rubric_names = _evaluator_names(trial_dir, result)
+    final_value = float(rewards["reward"])
+    scores = [
+        experiments.EvaluationResult(
+            evaluator=experiments.Evaluator(
+                evaluator_id="o11y-bench.verifier",
+                version=version,
+                kind=experiments.EvaluatorKind.CUSTOM.value,
+            ),
+            value=final_value,
+            passed=reward_counts_as_pass(result),
+            explanation=_overall_explanation(details),
+            score_key="final",
+            metadata={"source": "o11y-bench"},
+        )
+    ]
+    score_values = {name: value for name, value in rewards.items() if name != "reward"}
+    for name, value in details.items():
+        if name == "score" or name.startswith("explanation:") or name in score_values:
+            continue
+        if isinstance(value, (bool, int, float)):
+            score_values[name] = value
+    for name, raw_value in score_values.items():
+        try:
+            value = float(raw_value)
+        except TypeError, ValueError:
+            continue
+        is_check = name in check_names or name in {"checks_passed", "validators_passed"}
+        kind = (
+            experiments.EvaluatorKind.DETERMINISTIC.value
+            if is_check
+            else experiments.EvaluatorKind.LLM_JUDGE.value
+        )
+        prefix = "check" if is_check else "rubric"
+        scores.append(
+            experiments.EvaluationResult(
+                evaluator=experiments.Evaluator(
+                    evaluator_id=f"o11y-bench.{prefix}.{_slug(name)}",
+                    version=version,
+                    kind=kind,
+                ),
+                value=value,
+                passed=value >= 1.0,
+                explanation=str(details.get(f"explanation:{name}") or ""),
+                score_key=f"{prefix}.{_slug(name)}",
+                metadata={
+                    "source": "o11y-bench",
+                    "criterion": name,
+                    "evaluator_runtime": "harbor-verifier",
+                    "declared_in_suite": name in check_names or name in rubric_names,
+                },
+            )
+        )
+    return scores
+
+
+def _evaluator_names(trial_dir: Path, result: dict[str, Any]) -> tuple[set[str], set[str]]:
+    task_name = str(result.get("task_name") or trial_dir.name.split("__", 1)[0])
+    problem_path = trial_dir / "config.json"
+    task_root: Path | None = None
+    try:
+        config = json.loads(problem_path.read_text())
+        raw_task_path = (config.get("task") or {}).get("path")
+        if isinstance(raw_task_path, str) and raw_task_path:
+            task_root = Path(raw_task_path)
+    except OSError, json.JSONDecodeError:
+        pass
+    candidates = [
+        task_root / "tests" / "problem.yaml" if task_root is not None else None,
+        trial_dir.parent.parent / "tasks" / task_name / "tests" / "problem.yaml",
+    ]
+    payload: dict[str, Any] = {}
+    for candidate in candidates:
+        if candidate is None or not candidate.exists():
+            continue
+        loaded = yaml.safe_load(candidate.read_text())
+        if isinstance(loaded, dict):
+            payload = loaded
+            break
+    checks = {
+        str(item.get("name"))
+        for item in payload.get("checks", [])
+        if isinstance(item, dict) and item.get("name")
+    }
+    rubrics = {
+        str(item.get("criterion"))
+        for item in payload.get("rubric", [])
+        if isinstance(item, dict) and item.get("criterion")
+    }
+    return checks, rubrics
+
+
+def _grading_details(trial_dir: Path) -> dict[str, Any]:
+    path = trial_dir / "verifier" / "grading_details.json"
+    try:
+        payload = json.loads(path.read_text())
+    except OSError, json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _overall_explanation(details: dict[str, Any]) -> str:
+    explanations = [
+        str(value)
+        for key, value in details.items()
+        if str(key).startswith("explanation:") and value
+    ]
+    return "\n".join(explanations)
+
+
+def _final_output(trial_dir: Path) -> str:
+    transcript = parse_transcript(trial_dir / "agent")
+    for message in reversed(transcript.messages):
+        if message.role == "assistant" and message.content:
+            return message.content
+    return ""
+
+
+def _artifact_paths(trial_dir: Path) -> list[tuple[str, Path]]:
+    paths: list[tuple[str, Path]] = []
+    agent_dir = trial_dir / "agent"
+    for name, pattern in (
+        ("harbor-trajectory", "trajectory.json"),
+        ("harbor-transcript", "transcript.jsonl"),
+    ):
+        matches = sorted(agent_dir.rglob(pattern)) if agent_dir.exists() else []
+        if matches:
+            paths.append((name, matches[0]))
+    grading = trial_dir / "verifier" / "grading_details.json"
+    if grading.exists():
+        paths.append(("grading-details", grading))
+    return paths
+
+
+def _result_model_ref(result: dict[str, Any], fallback: str) -> tuple[str, str]:
+    model_info = (result.get("agent_info") or {}).get("model_info") or {}
+    provider = str(model_info.get("provider") or "")
+    name = str(model_info.get("name") or fallback)
+    fallback_provider, fallback_name = _model_ref(fallback)
+    if "/" in name:
+        embedded_provider, name = name.split("/", 1)
+        provider = provider or embedded_provider
+    return provider or fallback_provider, name or fallback_name
+
+
+def _model_ref(model: str) -> tuple[str, str]:
+    provider, separator, name = model.partition("/")
+    return (provider, name) if separator else ("", model)
+
+
+def _default_experiment_id(job_dir: Path) -> str:
+    digest = hashlib.sha1(str(job_dir.resolve()).encode()).hexdigest()[:10]
+    return f"o11y-bench-{job_dir.name}-{digest}"
+
+
+def _slug(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "score"
+    if len(normalized) <= 80:
+        return normalized
+    digest = hashlib.sha1(value.encode()).hexdigest()[:10]
+    return f"{normalized[:69]}-{digest}"
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def trial_reasoning_label(model: str) -> str:
+    return f"candidate:{model}"
+
+
+def _import_agento11y() -> tuple[Any, Any]:
+    try:
+        import agento11y
+        from agento11y import experiments
+    except ImportError as exc:
+        raise RuntimeError(
+            "Agent Observability publishing requires agento11y>=0.11.0. "
+            "Run `mise run agento11y:setup` to install the published SDK."
+        ) from exc
+    return agento11y, experiments

--- a/o11y_bench/agento11y_publish.py
+++ b/o11y_bench/agento11y_publish.py
@@ -105,7 +105,7 @@ class Agento11yLivePublisher:
         if self._experiment is not None:
             return str(self._experiment.url)
         base = os.getenv("AGENTO11Y_GRAFANA_URL", "").rstrip("/")
-        return f"{base}/a/grafana-sigil-app/experiments/runs/{self.experiment_id}"
+        return f"{base}/a/grafana-agento11y-app/experiments/runs/{self.experiment_id}"
 
     def start(self) -> None:
         self._connect()
@@ -520,7 +520,7 @@ def _import_agento11y() -> tuple[Any, Any]:
         from agento11y import experiments
     except ImportError as exc:
         raise RuntimeError(
-            "Agent Observability publishing requires agento11y>=0.11.0. "
+            "Agent Observability publishing requires agento11y>=0.12.0. "
             "Run `mise run agento11y:setup` to install the published SDK."
         ) from exc
     return agento11y, experiments

--- a/o11y_bench/agento11y_suite.py
+++ b/o11y_bench/agento11y_suite.py
@@ -1,0 +1,156 @@
+"""Build and synchronize an Agent Observability suite from o11y-bench task specs."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlsplit, urlunsplit
+
+import yaml
+
+from .config import ROOT
+
+DEFAULT_SUITE_ID = "o11y-bench"
+DEFAULT_SPECS_DIR = ROOT / "tasks-spec"
+
+
+def build_test_suite(specs_dir: Path = DEFAULT_SPECS_DIR) -> Any:
+    """Convert source-controlled task YAML files to the Agent Observability suite shape."""
+
+    agento11y = _import_agento11y()
+    cases: list[Any] = []
+    seen: set[str] = set()
+    for path in sorted(specs_dir.rglob("*.yaml")):
+        payload = yaml.safe_load(path.read_text())
+        if not isinstance(payload, dict):
+            raise ValueError(f"task spec must be a mapping: {path}")
+        case_id = str(payload.get("id") or "").strip()
+        if not case_id:
+            raise ValueError(f"task spec is missing id: {path}")
+        if case_id in seen:
+            raise ValueError(f"duplicate task id {case_id!r}: {path}")
+        seen.add(case_id)
+        statement = str(payload.get("statement") or "").strip()
+        if not statement:
+            raise ValueError(f"task spec {case_id!r} is missing statement: {path}")
+
+        expected = {
+            key: payload[key]
+            for key in ("checks", "rubric")
+            if isinstance(payload.get(key), list) and payload[key]
+        }
+        try:
+            relative_path = path.relative_to(ROOT).as_posix()
+        except ValueError:
+            relative_path = path.relative_to(specs_dir).as_posix()
+        cases.append(
+            agento11y.TestCase(
+                test_case_id=case_id,
+                name=case_id.replace("-", " ").title(),
+                description=statement,
+                tags=[str(tag) for tag in payload.get("tags", [])],
+                category=str(payload.get("category") or ""),
+                input=statement,
+                expected=expected,
+                metadata={
+                    "source": "o11y-bench",
+                    "source_path": relative_path,
+                    "spec_format": "o11y-bench/task-spec-v1",
+                },
+            )
+        )
+
+    if not cases:
+        raise ValueError(f"no task specs found under {specs_dir}")
+    return agento11y.TestSuite(
+        suite_id=os.getenv("AGENTO11Y_SUITE_ID", DEFAULT_SUITE_ID).strip() or DEFAULT_SUITE_ID,
+        name="o11y-bench",
+        description="Observability and SRE agent benchmark maintained in o11y-bench task YAML.",
+        tags=["o11y-bench", "observability", "sre"],
+        test_cases=cases,
+    )
+
+
+def sync_test_suite(
+    *,
+    specs_dir: Path = DEFAULT_SPECS_DIR,
+    publish: bool = True,
+    progress: Callable[[str], None] | None = None,
+) -> Any:
+    """Push the source suite to Agent Observability and optionally publish its draft."""
+
+    agento11y = _import_agento11y()
+    if progress is not None:
+        progress(f"[1/2] Loading and validating test cases from {specs_dir}")
+    suite = build_test_suite(specs_dir)
+    action = "uploading and publishing" if publish else "uploading as a draft"
+    if progress is not None:
+        progress(f"[2/2] {action.capitalize()} {len(suite.cases)} test cases")
+    return agento11y.TestSuitesClient().push_suite(
+        suite,
+        publish=publish,
+        changelog="Synchronized from o11y-bench task specs",
+        prune=True,
+    )
+
+
+def test_suite_url(suite_id: str) -> str:
+    """Build the Grafana test-suite deep link from the configured control URL."""
+
+    control_url = os.getenv("AGENTO11Y_CONTROL_ENDPOINT", "").strip()
+    grafana_url = os.getenv("AGENTO11Y_GRAFANA_URL", "").strip()
+    source = control_url or grafana_url
+    if not source:
+        return ""
+    parsed = urlsplit(source)
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    app_path = "/a/grafana-sigil-app"
+    if app_path in parsed.path:
+        base_path = parsed.path.split(app_path, 1)[0] + app_path
+    else:
+        grafana_parsed = urlsplit(grafana_url) if grafana_url else parsed
+        parsed = grafana_parsed
+        base_path = app_path
+    base = urlunsplit((parsed.scheme, parsed.netloc, base_path.rstrip("/"), "", ""))
+    return f"{base}/experiments/test-suites/{quote(suite_id, safe='')}"
+
+
+def _import_agento11y() -> Any:
+    try:
+        from agento11y import experiments
+    except ImportError as exc:
+        raise RuntimeError(
+            "Agent Observability publishing requires agento11y>=0.11.0. "
+            "Run `mise run agento11y:setup` to install the published SDK."
+        ) from exc
+    return experiments
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Synchronize o11y-bench task specs to Agent Observability"
+    )
+    parser.add_argument("--path", type=Path, default=DEFAULT_SPECS_DIR)
+    parser.add_argument("--no-publish", action="store_true")
+    args = parser.parse_args()
+    pushed = sync_test_suite(
+        specs_dir=args.path,
+        publish=not args.no_publish,
+        progress=lambda message: print(message, flush=True),
+    )
+    state = "published" if pushed.published else "draft"
+    print(
+        f"Synchronized {len(pushed.suite.cases)} cases to "
+        f"{pushed.suite_id}@{pushed.suite_version} ({state})"
+    )
+    url = test_suite_url(pushed.suite_id)
+    if url:
+        print(f"View the test suite here: {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/o11y_bench/agento11y_suite.py
+++ b/o11y_bench/agento11y_suite.py
@@ -108,7 +108,7 @@ def test_suite_url(suite_id: str) -> str:
     parsed = urlsplit(source)
     if not parsed.scheme or not parsed.netloc:
         return ""
-    app_path = "/a/grafana-sigil-app"
+    app_path = "/a/grafana-agento11y-app"
     if app_path in parsed.path:
         base_path = parsed.path.split(app_path, 1)[0] + app_path
     else:
@@ -124,7 +124,7 @@ def _import_agento11y() -> Any:
         from agento11y import experiments
     except ImportError as exc:
         raise RuntimeError(
-            "Agent Observability publishing requires agento11y>=0.11.0. "
+            "Agent Observability publishing requires agento11y>=0.12.0. "
             "Run `mise run agento11y:setup` to install the published SDK."
         ) from exc
     return experiments

--- a/o11y_bench/cli.py
+++ b/o11y_bench/cli.py
@@ -50,6 +50,11 @@ def main() -> None:
     suite_parser.add_argument("--no-resume", action="store_true")
     suite_parser.add_argument("--dry-run", action="store_true")
     suite_parser.add_argument("--quiet", action="store_true")
+    suite_parser.add_argument(
+        "--agento11y-publish",
+        action="store_true",
+        help="Publish each completed trial to an Agent Observability experiment",
+    )
     suite_parser.add_argument("--n-attempts", type=int, default=DEFAULT_N_ATTEMPTS)
     suite_parser.add_argument("--n-concurrent", type=int, default=DEFAULT_N_CONCURRENT)
     suite_parser.add_argument("--override-cpus", type=int)
@@ -82,6 +87,11 @@ def main() -> None:
     )
     job_parser.add_argument("--dry-run", action="store_true")
     job_parser.add_argument("--quiet", action="store_true")
+    job_parser.add_argument(
+        "--agento11y-publish",
+        action="store_true",
+        help="Publish each completed trial to an Agent Observability experiment",
+    )
 
     # --- finalize: stamp checksums + generate per-job report ---
     finalize_parser = subparsers.add_parser(
@@ -156,6 +166,7 @@ def _cmd_suite(args: argparse.Namespace) -> None:
             n_attempts=args.n_attempts,
             n_concurrent=args.n_concurrent,
             tasks_dir=_resolve_tasks_path(args.path),
+            agento11y_publish=args.agento11y_publish,
             override_cpus=args.override_cpus,
             override_memory_mb=args.override_memory_mb,
             override_storage_mb=args.override_storage_mb,
@@ -199,7 +210,17 @@ def _cmd_job(args: argparse.Namespace) -> None:
     if not args.dry_run:
         run_preflight(quiet=args.quiet)
 
-    result = execute_job(spec, dry_run=args.dry_run, quiet=args.quiet)
+    execute_kwargs = {"dry_run": args.dry_run, "quiet": args.quiet}
+    if getattr(args, "agento11y_publish", False):
+        execute_kwargs["agento11y_publish"] = True
+    result = execute_job(spec, **execute_kwargs)
+    if result.agento11y_result and not args.quiet:
+        published = result.agento11y_result
+        print(
+            f"Published {published.trial_count} trial(s) and {published.score_count} score(s) "
+            f"to Agent Observability experiment {published.experiment_id}"
+        )
+        print(f"View in Agent Observability: {published.url}")
     if result.harbor_exit_code and result.harbor_exit_code != 0:
         raise SystemExit(result.harbor_exit_code)
 

--- a/o11y_bench/config.py
+++ b/o11y_bench/config.py
@@ -95,6 +95,7 @@ class SuiteOpts:
     n_attempts: int
     n_concurrent: int
     tasks_dir: Path
+    agento11y_publish: bool = False
     override_cpus: int | None = None
     override_memory_mb: int | None = None
     override_storage_mb: int | None = None

--- a/o11y_bench/run.py
+++ b/o11y_bench/run.py
@@ -21,6 +21,7 @@ from reporting.report_paths import (
     run_report_output_path,
 )
 
+from .agento11y_publish import Agento11yLivePublisher, Agento11yPublishResult
 from .config import (
     PROVIDERS,
     ROOT,
@@ -55,6 +56,7 @@ class JobResult:
     missing_trials: int = 0
     harbor_exit_code: int | None = None
     report_path: Path | None = None
+    agento11y_result: Agento11yPublishResult | None = None
 
 
 def _print_job_summary(result: JobResult) -> None:
@@ -74,8 +76,46 @@ def _print_job_summary(result: JobResult) -> None:
 
     if result.report_path:
         message = f"{message} | report: {result.report_path}"
+    if result.agento11y_result:
+        message = f"{message} | Agent Observability: {result.agento11y_result.url}"
 
     print(f"{result.job_name}: {message}")
+
+
+def _make_agento11y_publisher(spec: JobSpec, job_dir: Path) -> Agento11yLivePublisher:
+    agent_name = os.getenv("AGENTO11Y_AGENT_NAME", "").strip()
+    if not agent_name:
+        agent_name = spec.agent or spec.agent_import_path.split(":", 1)[0].rsplit(".", 1)[-1]
+    agent_version = os.getenv("AGENTO11Y_AGENT_VERSION", "").strip() or "unknown"
+    return Agento11yLivePublisher(
+        job_dir,
+        spec.tasks_dir,
+        model=spec.model,
+        agent_name=agent_name,
+        agent_version=agent_version,
+        planned_trial_count=len(_selected_task_names(spec)) * spec.n_attempts,
+    )
+
+
+def _run_harbor_with_agento11y(
+    command: list[str],
+    *,
+    publisher: Agento11yLivePublisher | None,
+) -> tuple[int, Agento11yPublishResult | None]:
+    if publisher is None:
+        return run_harbor(command, forward_signals=False), None
+
+    publisher.start()
+    exit_code = 1
+    error = ""
+    try:
+        exit_code = run_harbor(command, forward_signals=False)
+    except BaseException as exc:
+        error = str(exc)
+        raise
+    finally:
+        result = publisher.finish(succeeded=exit_code == 0 and not error, error=error)
+    return exit_code, result
 
 
 def _selected_task_names(spec: JobSpec) -> list[str]:
@@ -490,10 +530,19 @@ def execute_regrade(target_dir: Path, *, tasks_dir: Path, quiet: bool = False) -
         suite_report.write_report(target_dir, tasks_dir=tasks_dir, quiet=quiet)
 
 
-def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) -> JobResult:
+def execute_job(
+    spec: JobSpec,
+    *,
+    dry_run: bool = False,
+    quiet: bool = False,
+    agento11y_publish: bool = False,
+) -> JobResult:
     """Single-pass: plan, repair, run harbor, finalize."""
     task_checksums = compute_task_checksums(spec.tasks_dir)
     job_dir = spec.jobs_dir / spec.job_name
+    publisher = (
+        _make_agento11y_publisher(spec, job_dir) if agento11y_publish and not dry_run else None
+    )
     scenario_time_iso = resolve_scenario_time()
     os.environ["O11Y_SCENARIO_TIME_ISO"] = scenario_time_iso
     task_names = _selected_task_names(spec)
@@ -513,7 +562,9 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
             if quiet:
                 _print_job_summary(result)
             return result
-        fresh_harbor_exit_code = run_harbor(build_command(spec, quiet=quiet), forward_signals=False)
+        fresh_harbor_exit_code, fresh_publish_result = _run_harbor_with_agento11y(
+            build_command(spec, quiet=quiet), publisher=publisher
+        )
         report_path = finalize_job_dir(job_dir, spec.tasks_dir, task_checksums)
         result = JobResult(
             "fresh",
@@ -522,6 +573,7 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
             missing_trials=missing,
             harbor_exit_code=fresh_harbor_exit_code,
             report_path=report_path,
+            agento11y_result=fresh_publish_result,
         )
         if quiet:
             _print_job_summary(result)
@@ -554,7 +606,8 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
         return result
 
     if not needs_repair and not needs_harbor:
-        result = JobResult("up_to_date", spec.job_name)
+        existing_publish_result = publisher.publish_existing() if publisher is not None else None
+        result = JobResult("up_to_date", spec.job_name, agento11y_result=existing_publish_result)
         if quiet:
             _print_job_summary(result)
         return result
@@ -566,15 +619,18 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
                 print(f"  {note}")
 
     rerun_harbor_exit_code: int | None = None
+    publish_result: Agento11yPublishResult | None = None
     if needs_harbor:
-        rerun_harbor_exit_code = run_harbor(
+        rerun_harbor_exit_code, publish_result = _run_harbor_with_agento11y(
             build_resume_command(
                 str(job_dir / "config.json"),
                 quiet=quiet,
                 harbor_args=spec.harbor_args,
             ),
-            forward_signals=False,
+            publisher=publisher,
         )
+    elif publisher is not None:
+        publish_result = publisher.publish_existing()
 
     report_path = finalize_job_dir(job_dir, spec.tasks_dir, task_checksums)
     if report_path and not quiet:
@@ -589,6 +645,7 @@ def execute_job(spec: JobSpec, *, dry_run: bool = False, quiet: bool = False) ->
         missing_trials=missing,
         harbor_exit_code=rerun_harbor_exit_code,
         report_path=report_path,
+        agento11y_result=publish_result,
     )
     if quiet:
         _print_job_summary(result)
@@ -606,7 +663,12 @@ def _run_provider_queue(provider: str, suite_dir: Path, opts: SuiteOpts) -> list
         spec = build_suite_job_spec(suite_dir, provider, model, reasoning_effort, opts)
         if not opts.quiet:
             print(f"[{provider}] {model} ({reasoning_effort})")
-        result = execute_job(spec, dry_run=opts.dry_run, quiet=opts.quiet)
+        result = execute_job(
+            spec,
+            dry_run=opts.dry_run,
+            quiet=opts.quiet,
+            agento11y_publish=opts.agento11y_publish,
+        )
         results.append(result)
         if result.harbor_exit_code and result.harbor_exit_code != 0:
             print(f"[{provider}] Harbor failed (exit {result.harbor_exit_code})", file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,9 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.optional-dependencies]
+agento11y = ["agento11y>=0.11.0"]
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",
@@ -84,6 +87,8 @@ files = [
     "reporting/run_report.py",
     "reporting/summary.py",
     "o11y_bench/cli.py",
+    "o11y_bench/agento11y_publish.py",
+    "o11y_bench/agento11y_suite.py",
     "o11y_bench/config.py",
     "o11y_bench/harbor.py",
     "o11y_bench/resume.py",
@@ -94,6 +99,7 @@ files = [
 
 [[tool.mypy.overrides]]
 module = [
+    "agento11y",
     "promql_parser",
     "harbor.*",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-agento11y = ["agento11y>=0.11.0"]
+agento11y = ["agento11y>=0.12.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_agento11y_publish.py
+++ b/tests/test_agento11y_publish.py
@@ -273,7 +273,7 @@ def test_publisher_fallback_url_uses_current_experiment_route(monkeypatch, tmp_p
     )
 
     assert publisher.url == (
-        "https://example.grafana.net/a/grafana-sigil-app/experiments/runs/run-1"
+        "https://example.grafana.net/a/grafana-agento11y-app/experiments/runs/run-1"
     )
 
 

--- a/tests/test_agento11y_publish.py
+++ b/tests/test_agento11y_publish.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from o11y_bench import agento11y_publish
+
+
+@dataclass
+class FakeEvaluator:
+    evaluator_id: str
+    version: str
+    kind: str
+
+
+@dataclass
+class FakeEvaluationResult:
+    evaluator: FakeEvaluator
+    value: object
+    passed: bool
+    explanation: str = ""
+    score_key: str = "final"
+    metadata: dict | None = None
+
+
+class FakeEvaluatorKind:
+    CUSTOM = SimpleNamespace(value="custom")
+    DETERMINISTIC = SimpleNamespace(value="deterministic")
+    LLM_JUDGE = SimpleNamespace(value="llm_judge")
+
+
+class FakeClient:
+    def __init__(self):
+        self.generations = []
+        self.generation_flushes = 0
+        self.trial_updates = []
+
+    def record_generation(self, generation_id, **kwargs):
+        self.generations.append((generation_id, kwargs))
+
+    def flush_generations(self):
+        self.generation_flushes += 1
+
+    def update_trial(self, experiment_id, trial_id, **kwargs):
+        self.trial_updates.append((experiment_id, trial_id, kwargs))
+
+
+class FakeTrial:
+    def __init__(self, owner, attempt):
+        self.owner = owner
+        self.attempt = attempt
+        self.trial_id = f"trial-{attempt}"
+        self.pending = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def bind_generation(self, generation_id, *, conversation_id):
+        self.owner.bound.append((generation_id, conversation_id))
+
+    def set_usage(self, **usage):
+        self.owner.usage.append(usage)
+
+    def record_evaluation(self, result):
+        self.owner.events.append(("record", result.score_key, result.evaluator.kind))
+        self.pending += 1
+
+    def flush(self):
+        self.owner.events.append(("flush", self.pending))
+        count = self.pending
+        self.pending = 0
+        return count
+
+    def artifact(self, name, *, path):
+        self.owner.artifacts.append((name, path))
+
+
+class FakeExperiment:
+    def __init__(self):
+        self.client = FakeClient()
+        self.suite = SimpleNamespace(
+            cases=[
+                SimpleNamespace(
+                    test_case_id="task-a",
+                    input="Investigate.",
+                    category="investigation",
+                )
+            ]
+        )
+        self.events = []
+        self.bound = []
+        self.usage = []
+        self.artifacts = []
+        self.exit = None
+        self.url = "https://example.test/experiment/run-1"
+        self.create_kwargs = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, _tb):
+        self.exit = (exc_type, exc)
+        return False
+
+    def trial(self, _case, *, attempt, metadata):
+        assert metadata["harbor_trial_id"] == "task-a__abc"
+        return FakeTrial(self, attempt)
+
+
+def _fake_modules(experiment):
+    def experiment_from_suite(*_args, **kwargs):
+        experiment.create_kwargs = kwargs
+        return experiment
+
+    sdk = SimpleNamespace(TokenUsage=lambda **kwargs: kwargs)
+    experiments = SimpleNamespace(
+        EvaluationResult=FakeEvaluationResult,
+        Evaluator=FakeEvaluator,
+        EvaluatorKind=FakeEvaluatorKind,
+        experiment_from_suite=experiment_from_suite,
+        stable_id=lambda prefix, *_parts: f"{prefix}-stable",
+    )
+    return sdk, experiments
+
+
+def _write_trial(tmp_path):
+    tasks_dir = tmp_path / "tasks"
+    task_dir = tasks_dir / "task-a"
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "tests" / "problem.yaml").write_text(
+        """\
+id: task-a
+category: investigation
+statement: Investigate.
+checks:
+  - name: queried_metrics
+    weight: 1
+rubric:
+  - criterion: grounded answer
+    weight: 1
+"""
+    )
+    job_dir = tmp_path / "jobs" / "job-a"
+    trial_dir = job_dir / "task-a__abc"
+    (trial_dir / "verifier").mkdir(parents=True)
+    (trial_dir / "config.json").write_text(json.dumps({"task": {"path": str(task_dir)}}))
+    (trial_dir / "verifier" / "grading_details.json").write_text(
+        json.dumps(
+            {
+                "queried_metrics": 1.0,
+                "grounded answer": 1.0,
+                "explanation:queried_metrics": "metric query found",
+                "explanation:grounded answer": "answer used evidence",
+            }
+        )
+    )
+    result = {
+        "__result_path": str(trial_dir / "result.json"),
+        "task_name": "task-a",
+        "task_checksum": "checksum-1",
+        "agent_info": {"model_info": {"provider": "anthropic", "name": "claude-test"}},
+        "agent_result": {
+            "n_input_tokens": 10,
+            "n_cache_tokens": 3,
+            "n_output_tokens": 5,
+            "cost_usd": 0.01,
+            "metadata": {"reasoning_effort": "high"},
+        },
+        "agent_execution": {
+            "started_at": "2026-01-01T00:00:00Z",
+            "finished_at": "2026-01-01T00:00:02Z",
+        },
+        "verifier_result": {
+            "rewards": {
+                "reward": 0.75,
+            }
+        },
+    }
+    return job_dir, tasks_dir, result
+
+
+def test_live_publisher_flushes_every_score_and_preserves_evaluator_kind(monkeypatch, tmp_path):
+    job_dir, tasks_dir, result = _write_trial(tmp_path)
+    experiment = FakeExperiment()
+    monkeypatch.setattr(agento11y_publish, "_import_agento11y", lambda: _fake_modules(experiment))
+    monkeypatch.setattr(agento11y_publish, "load_trials", lambda _path: [result])
+    monkeypatch.setattr(agento11y_publish, "_final_output", lambda _path: "Final answer")
+    monkeypatch.setattr(agento11y_publish, "_artifact_paths", lambda _path: [])
+
+    publisher = agento11y_publish.Agento11yLivePublisher(
+        job_dir,
+        tasks_dir,
+        model="anthropic/claude-test",
+        agent_name="o11y-bench",
+        agent_version="test",
+        options=agento11y_publish.Agento11yPublishOptions(
+            experiment_id="run-1", suite_version="v1"
+        ),
+        planned_trial_count=3,
+    )
+    publisher._connect()
+    publisher.scan_once()
+
+    assert experiment.create_kwargs["planned_trial_count"] == 3
+    assert experiment.events == [
+        ("record", "final", "custom"),
+        ("flush", 1),
+        ("record", "check.queried-metrics", "deterministic"),
+        ("flush", 1),
+        ("record", "rubric.grounded-answer", "llm_judge"),
+        ("flush", 1),
+    ]
+    assert publisher._score_count == 3
+    assert publisher._trial_count == 1
+    assert experiment.client.generation_flushes == 1
+    assert experiment.usage == [{"cost": 0.01}]
+    assert experiment.client.trial_updates[0][2]["duration_ms"] == 2000
+    assert "input_tokens" not in experiment.client.trial_updates[0][2]
+
+    state = json.loads((job_dir / ".agento11y-publish.json").read_text())
+    assert state["attempts"]["task-a\u001ftask-a__abc"] == 1
+    assert state["exported_trials"] == ["task-a__abc"]
+
+
+def test_publisher_reuses_persisted_attempt_mapping(monkeypatch, tmp_path):
+    job_dir, tasks_dir, result = _write_trial(tmp_path)
+    experiment = FakeExperiment()
+    monkeypatch.setattr(agento11y_publish, "_import_agento11y", lambda: _fake_modules(experiment))
+    monkeypatch.setattr(agento11y_publish, "load_trials", lambda _path: [result])
+    monkeypatch.setattr(agento11y_publish, "_final_output", lambda _path: "Final answer")
+    monkeypatch.setattr(agento11y_publish, "_artifact_paths", lambda _path: [])
+    options = agento11y_publish.Agento11yPublishOptions(experiment_id="run-1", suite_version="v1")
+    first = agento11y_publish.Agento11yLivePublisher(
+        job_dir,
+        tasks_dir,
+        model="anthropic/claude-test",
+        agent_name="o11y-bench",
+        agent_version="test",
+        options=options,
+    )
+    first._connect()
+    first.scan_once()
+
+    second = agento11y_publish.Agento11yLivePublisher(
+        job_dir,
+        tasks_dir,
+        model="anthropic/claude-test",
+        agent_name="o11y-bench",
+        agent_version="test",
+        options=options,
+    )
+    assert second._attempt_for("task-a", "task-a__abc") == 1
+    second._connect()
+    second.scan_once()
+    assert second._trial_count == 1
+
+
+def test_publisher_fallback_url_uses_current_experiment_route(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTO11Y_GRAFANA_URL", "https://example.grafana.net/")
+    publisher = agento11y_publish.Agento11yLivePublisher(
+        tmp_path / "job",
+        tmp_path / "tasks",
+        model="anthropic/claude-test",
+        agent_name="o11y-bench",
+        agent_version="test",
+        options=agento11y_publish.Agento11yPublishOptions(experiment_id="run-1"),
+    )
+
+    assert publisher.url == (
+        "https://example.grafana.net/a/grafana-sigil-app/experiments/runs/run-1"
+    )
+
+
+def test_publisher_error_marks_experiment_failed(monkeypatch, tmp_path):
+    experiment = FakeExperiment()
+    publisher = agento11y_publish.Agento11yLivePublisher(
+        tmp_path / "job",
+        tmp_path / "tasks",
+        model="anthropic/claude-test",
+        agent_name="o11y-bench",
+        agent_version="test",
+        options=agento11y_publish.Agento11yPublishOptions(
+            experiment_id="run-1", suite_version="v1"
+        ),
+    )
+    publisher._experiment = experiment
+    publisher._error = ValueError("score export failed")
+    monkeypatch.setattr(publisher, "scan_once", lambda: None)
+
+    with pytest.raises(RuntimeError, match="score export failed"):
+        publisher.finish(succeeded=True)
+
+    assert experiment.exit is not None
+    assert experiment.exit[0] is RuntimeError
+    assert "score export failed" in str(experiment.exit[1])
+
+
+def test_long_score_slugs_are_bounded_and_collision_resistant():
+    common = "A very long criterion " * 10
+    first = agento11y_publish._slug(common + "first")
+    second = agento11y_publish._slug(common + "second")
+
+    assert len(first) == 80
+    assert len(second) == 80
+    assert first != second

--- a/tests/test_agento11y_suite.py
+++ b/tests/test_agento11y_suite.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+
+from o11y_bench import agento11y_suite
+
+
+@dataclass
+class FakeCase:
+    test_case_id: str
+    name: str = ""
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    category: str = ""
+    input: object = None
+    expected: object = None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class FakeSuite:
+    suite_id: str
+    name: str = ""
+    description: str = ""
+    tags: list[str] = field(default_factory=list)
+    test_cases: list[FakeCase] = field(default_factory=list)
+
+    @property
+    def cases(self):
+        return self.test_cases
+
+
+def test_build_test_suite_uses_task_yaml_as_source_of_truth(monkeypatch, tmp_path):
+    spec = tmp_path / "investigation" / "incident.yaml"
+    spec.parent.mkdir()
+    spec.write_text(
+        """\
+id: incident
+category: investigation
+tags: [metrics, logs]
+statement: Investigate the incident.
+checks:
+  - name: queried_metrics
+    weight: 1
+rubric:
+  - criterion: The answer identifies the cause.
+    weight: 1
+"""
+    )
+    fake = SimpleNamespace(TestCase=FakeCase, TestSuite=FakeSuite)
+    monkeypatch.setattr(agento11y_suite, "_import_agento11y", lambda: fake)
+
+    suite = agento11y_suite.build_test_suite(tmp_path)
+
+    assert suite.suite_id == "o11y-bench"
+    assert len(suite.cases) == 1
+    case = suite.cases[0]
+    assert case.test_case_id == "incident"
+    assert case.input == "Investigate the incident."
+    assert case.expected["checks"][0]["name"] == "queried_metrics"
+    assert case.expected["rubric"][0]["criterion"] == "The answer identifies the cause."
+    assert case.category == "investigation"
+    assert case.tags == ["metrics", "logs"]
+
+
+def test_build_test_suite_rejects_duplicate_ids(monkeypatch, tmp_path):
+    for directory in ("one", "two"):
+        path = tmp_path / directory / "task.yaml"
+        path.parent.mkdir()
+        path.write_text("id: duplicate\ncategory: test\nstatement: Run it.\n")
+    fake = SimpleNamespace(TestCase=FakeCase, TestSuite=FakeSuite)
+    monkeypatch.setattr(agento11y_suite, "_import_agento11y", lambda: fake)
+
+    try:
+        agento11y_suite.build_test_suite(tmp_path)
+    except ValueError as exc:
+        assert "duplicate task id" in str(exc)
+    else:
+        raise AssertionError("expected duplicate task ids to fail")
+
+
+def test_suite_url_uses_configured_grafana_app_control_url(monkeypatch):
+    monkeypatch.setenv(
+        "AGENTO11Y_CONTROL_ENDPOINT",
+        "https://dev.grafana-dev.net/a/grafana-sigil-app",
+    )
+
+    assert agento11y_suite.test_suite_url("o11y-bench/jack") == (
+        "https://dev.grafana-dev.net/a/grafana-sigil-app/experiments/test-suites/o11y-bench%2Fjack"
+    )
+
+
+def test_suite_url_uses_grafana_url_for_direct_control_endpoint(monkeypatch):
+    monkeypatch.setenv("AGENTO11Y_CONTROL_ENDPOINT", "http://sigil:8080/api/v1/eval")
+    monkeypatch.setenv("AGENTO11Y_GRAFANA_URL", "http://localhost:3000")
+
+    assert agento11y_suite.test_suite_url("o11y-bench") == (
+        "http://localhost:3000/a/grafana-sigil-app/experiments/test-suites/o11y-bench"
+    )

--- a/tests/test_agento11y_suite.py
+++ b/tests/test_agento11y_suite.py
@@ -83,18 +83,18 @@ def test_build_test_suite_rejects_duplicate_ids(monkeypatch, tmp_path):
 def test_suite_url_uses_configured_grafana_app_control_url(monkeypatch):
     monkeypatch.setenv(
         "AGENTO11Y_CONTROL_ENDPOINT",
-        "https://dev.grafana-dev.net/a/grafana-sigil-app",
+        "https://dev.grafana-dev.net/a/grafana-agento11y-app",
     )
 
     assert agento11y_suite.test_suite_url("o11y-bench/jack") == (
-        "https://dev.grafana-dev.net/a/grafana-sigil-app/experiments/test-suites/o11y-bench%2Fjack"
+        "https://dev.grafana-dev.net/a/grafana-agento11y-app/experiments/test-suites/o11y-bench%2Fjack"
     )
 
 
 def test_suite_url_uses_grafana_url_for_direct_control_endpoint(monkeypatch):
-    monkeypatch.setenv("AGENTO11Y_CONTROL_ENDPOINT", "http://sigil:8080/api/v1/eval")
+    monkeypatch.setenv("AGENTO11Y_CONTROL_ENDPOINT", "http://agento11y:8080/api/v1/eval")
     monkeypatch.setenv("AGENTO11Y_GRAFANA_URL", "http://localhost:3000")
 
     assert agento11y_suite.test_suite_url("o11y-bench") == (
-        "http://localhost:3000/a/grafana-sigil-app/experiments/test-suites/o11y-bench"
+        "http://localhost:3000/a/grafana-agento11y-app/experiments/test-suites/o11y-bench"
     )

--- a/tests/test_run_job.py
+++ b/tests/test_run_job.py
@@ -53,6 +53,30 @@ def test_build_command_maps_task_filters_to_harbor_include_task_name() -> None:
     assert "dashboard-create-service-overview" in command
 
 
+def test_agento11y_publisher_receives_exact_planned_trial_count(monkeypatch, tmp_path) -> None:
+    captured: dict[str, object] = {}
+
+    class FakePublisher:
+        def __init__(self, job_dir, tasks_dir, **kwargs):
+            captured.update(job_dir=job_dir, tasks_dir=tasks_dir, **kwargs)
+
+    monkeypatch.setattr(run, "Agento11yLivePublisher", FakePublisher)
+    spec = config.JobSpec(
+        jobs_dir=tmp_path / "jobs",
+        job_name="test-job",
+        tasks_dir=tmp_path / "tasks",
+        model="anthropic/claude-sonnet-4-6",
+        reasoning_effort="off",
+        n_attempts=3,
+        n_concurrent=1,
+        task_names=("task-a", "task-b"),
+    )
+
+    run._make_agento11y_publisher(spec, spec.jobs_dir / spec.job_name)
+
+    assert captured["planned_trial_count"] == 6
+
+
 def test_build_resume_command_uses_saved_job_config() -> None:
     command = harbor.build_resume_command("/tmp/job/config.json")
 
@@ -407,6 +431,32 @@ def test_main_passes_unknown_job_args_through_to_harbor(monkeypatch) -> None:
 
     assert len(execute_calls) == 1
     assert execute_calls[0].harbor_args == ("--ak", "temperature=0")
+
+
+def test_main_enables_agento11y_publishing_only_with_explicit_flag(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "o11y_bench",
+            "job",
+            "--model",
+            "openai/gpt-5.4-nano",
+            "--dry-run",
+            "--agento11y-publish",
+        ],
+    )
+    calls: list[dict[str, object]] = []
+
+    def fake_execute_job(spec: config.JobSpec, **kwargs):
+        calls.append(kwargs)
+        return run.JobResult(status="dry_run", job_name=spec.job_name)
+
+    monkeypatch.setattr(cli, "execute_job", fake_execute_job)
+
+    cli.main()
+
+    assert calls == [{"dry_run": True, "quiet": False, "agento11y_publish": True}]
 
 
 def test_main_rejects_unknown_args_before_job_subcommand(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,25 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agento11y"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "protobuf" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/ae/152a560490f7db6544e95551debbf1af8a544275185e2304d29020cdf2dd/agento11y-0.12.0.tar.gz", hash = "sha256:3f457902f74bd0ef455c218d1cfc359912b8897aaa9235b8de8fbfaa54a863a4", size = 197383, upload-time = "2026-07-27T20:23:56.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/07/755e76459dbb09d6e646cb23db154e6655ffab077465bd565c4d882d70d4/agento11y-0.12.0-py3-none-any.whl", hash = "sha256:c1bfdd8bb9d027503e79189c6a90f24bc137de2388860e9c80fd769bd6994517", size = 125364, upload-time = "2026-07-27T20:23:55.476Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -477,6 +496,39 @@ wheels = [
 [package.optional-dependencies]
 http = [
     { name = "aiohttp" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/60/f2cca8147ea213d3e43ae9158d03ad04e020fdf32ff027253e1fe93f921d/grpcio-1.83.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3f351629f6ae16ecc0ec3553e586a6763ffd9f6114044286d0cbec3e09241bfa", size = 6305607, upload-time = "2026-07-23T15:20:15.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ab/d3874931d123a95e83a3ebf8aa04537988fb62425cedb8bf3cefc5ad41b2/grpcio-1.83.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d05ff664100d429335b93c91b8b34ddf9e94a112205e7fa06dede309e44a4e4c", size = 12166617, upload-time = "2026-07-23T15:20:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ff/6f18f9426b69306f4e00a9add3b0ee2748da8aad53836ef80cab0d62d04f/grpcio-1.83.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7936f2a56cf04f6514705c0fedf400971de01b6aa1719327e4718f410a765e2b", size = 6880213, upload-time = "2026-07-23T15:20:19.98Z" },
+    { url = "https://files.pythonhosted.org/packages/70/21/706d1147c6b93b98f179240c13991fbcc56880eba0c868abb1ad40d8a0a6/grpcio-1.83.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:b0a0be840e51b6b7ee9df9269770faf77bdf4b771053c257c21d12bad607714c", size = 7618335, upload-time = "2026-07-23T15:20:22.161Z" },
+    { url = "https://files.pythonhosted.org/packages/74/04/1a8443c889115ec9e213a213e86bc93a71ee9088027e5befa09aaa0edd9d/grpcio-1.83.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:009667eaf3dcd5224c713589cdc98e7ca4ed0ff0b61132c6b276e930eb83a2df", size = 7043416, upload-time = "2026-07-23T15:20:24.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c6/94e0fee5b12bc1da1370185b680988db6f739d19b42d9959db01a7ea50bf/grpcio-1.83.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bb669918fd88936b15599caff4160a77ab74bdeb25f2231f6e45b61282d6107b", size = 7583253, upload-time = "2026-07-23T15:20:26.313Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/97/de1ccb671fb85575bc5192faedf9ecdbdf5b390d2e6584dcf552bcbd370e/grpcio-1.83.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:c19b454d3d3f28db81f2c7c4dbaee96e7f6fd149721733ffe79d6bc530f17404", size = 8605102, upload-time = "2026-07-23T15:20:28.437Z" },
+    { url = "https://files.pythonhosted.org/packages/17/0f/0e0ec749a7034ffcbaa050e39779872950ead90c22e7e0116be3f28b2b46/grpcio-1.83.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:61007cd08640abc5c54547ee32505474c482cd733a53cb87551ea81faa6350af", size = 7979826, upload-time = "2026-07-23T15:20:31.182Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/c3fda157287f64bc65acee6c5aa90c41acf9e0d3a8e69a265eecff6d00a1/grpcio-1.83.0-cp314-cp314-win32.whl", hash = "sha256:32e11c37f5285b0c6fa3042c05fe06903696689749833fc64e67dec71b9bbe33", size = 4471765, upload-time = "2026-07-23T15:20:33.195Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/00/b1b26431c9d54eee11724fd6e5585473a2ed47fbc1fb95e5204906a642ce/grpcio-1.83.0-cp314-cp314-win_amd64.whl", hash = "sha256:2bb48cb5e6dd005ca12b89ce4b6ac0b48ff3112c747542ee7986ef611a8ca6d9", size = 5298932, upload-time = "2026-07-23T15:20:35.48Z" },
 ]
 
 [[package]]
@@ -1060,6 +1112,11 @@ dependencies = [
     { name = "pyyaml" },
 ]
 
+[package.optional-dependencies]
+agento11y = [
+    { name = "agento11y" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
@@ -1071,6 +1128,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "agento11y", marker = "extra == 'agento11y'", specifier = ">=0.12.0" },
     { name = "anthropic", specifier = ">=0.40" },
     { name = "harbor", specifier = "==0.6.5" },
     { name = "markdown", specifier = ">=3.10" },
@@ -1078,6 +1136,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0" },
 ]
+provides-extras = ["agento11y"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1105,6 +1164,105 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
 ]
 
 [[package]]
@@ -1251,6 +1409,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
~~Note: in Draft and failing CI until https://github.com/grafana/agento11y/pull/453 is published with the latest `=0.11.0` version~~: PR Ready

## Notes

This adds optional Agent Observability publishing to o11y-bench without changing its role as a Harbor benchmark.

Harbor remains responsible for running and grading trials, `tasks-spec/**/*.yaml` remains the dataset source of truth, and ATIF remains the native trajectory format. Agent Observability receives the experiment lifecycle, candidate transcripts, scores, usage, cost, and artifacts for inspection and comparison.

## Usage Example

Configure the Agent Observability ingest and control-plane credentials in `.env` using the provided [.env.sample](https://github.com/grafana/o11y-bench/blob/01d994764f8cc0d53160ed9c5d4f7a12764dbec5/.env.sample).

### Publish the o11y-bench dataset as a test suite

```bash
mise run agento11y:sync-suite
```

This converts the source YAML into Agent Observability test cases, synchronizes the configured suite, removes remote-only cases, publishes the new version, and prints a direct link to the suite.

The remote suite name can be customized without changing the source dataset:

```bash
AGENTO11Y_SUITE_ID=o11y-bench-my-team \
mise run agento11y:sync-suite
```

### Run and publish a benchmark

A convenience mise task `agento11y:job` was added, which includes --agento11y-publish automatically:

  mise run agento11y:job -- \
    --model anthropic/claude-haiku-4-5-20251001 \
    --task-name promql-error-rate \
    --n-attempts 3

The equivalent direct CLI usage is:

```bash
uv run --with 'agento11y>=0.11.0' python -m o11y_bench job \
  --model anthropic/claude-haiku-4-5-20251001 \
  --task-name promql-error-rate \
  --n-attempts 3 \
  --agento11y-publish
```

## Publishing Behavior

Each Harbor trial is published immediately after it is scored rather than waiting for the entire job to finish.

Publishing state is retained in the Harbor job directory. Resumed jobs reuse stable experiment, trial, generation, and attempt identities instead of duplicating completed results.

### Other nits and improvements

- Exact planned trial counts so you can estimate the progress in the UI
- Current Agent Observability deep links
- Idempotent suite synchronization with progress output
- Explicit publishing opt-in