### PR TITLE
Fix agent_runner's mcp version to 1.x to match current harbor and avoid API break

### DIFF
--- a/agents/agent_runner.py
+++ b/agents/agent_runner.py
@@ -1,7 +1,8 @@
 # /// script
 # dependencies = [
 #   "litellm==1.83.10",
-#   "mcp>=1.9.0",
+#   # Match mcp version with harbor to avoid API breakage
+#   "mcp<2.0.0",
 # ]
 # ///
 """o11y-bench agent runner — executes inside the Harbor container.


### PR DESCRIPTION
[MCP 2.0](https://pypi.org/project/mcp/2.0.0/) is out, which has made breaking changes to its API for `streamable_http_client` and `Tool.inputSchema`. Running `agent_runner.py` fails right now as a result.

Harbor and claude-agent-sdk still rely on `mcp<2.0.0`

Fix the `agent_runner.py` script to match.