### PR TITLE
feat(tasks): add promql-retry-drain-rate gauge semantics task

### DIFF
--- a/tasks-spec/prometheus_query/promql-retry-drain-rate.yaml
+++ b/tasks-spec/prometheus_query/promql-retry-drain-rate.yaml
@@ -1,0 +1,42 @@
+# This task evaluates whether an agent can correctly describe the rate at which the payment retry backlog
+# drained after an incident. In order to succeed, the agent must
+#   - understand that the relevant metric is a gauge rather than a counter, and consequently must choose
+#     gauge-appropriate metrics, such as choosing derive() over rate()
+#   - understand that the answer must use a positive value to describe a rate of decrease (drain rate)
+#     rather than using a negative value to describe a rate of change
+#   - understand that the change is relative to the peak, and therefore must correctly identify the peak
+#     to be able to accurately answer the query
+
+id: promql-retry-drain-rate
+category: prometheus_query
+tags:
+- promql
+- gauge
+- deriv
+- backlog
+- drain
+statement: |
+  The payment retry backlog peaked and then recovered after the incident. Once it started
+  draining, roughly how fast was the payment-service backlog shrinking (items per minute), and
+  about how long did the drain take from peak back to zero? I want the drain speed, not just
+  the peak.
+checks: []
+rubric:
+- criterion: The final response states the payment-service backlog drain speed in items per minute accurately.
+  weight: 40
+  fact:
+    kind: query
+    backend: prometheus
+    query: min_over_time(deriv(service_retry_queue_depth{job="payment-service"}[10m])[3h:1m]) * -60
+- criterion: The final response states about how high the payment-service backlog peaked before draining, matching the canonical peak depth
+  weight: 15
+  fact:
+    kind: query
+    backend: prometheus
+    query: max_over_time(service_retry_queue_depth{job="payment-service"}[3h])
+- criterion: The final response states that the drain from peak back to zero took on the order of 20 minutes (any answer between 18 and 25 minutes counts)
+  weight: 15
+- criterion: The final response describes the backlog as decreasing, draining, or shrinking during the post-peak recovery window, and does not claim it was growing or report a large positive growth rate for that window (as produced by applying rate() or increase() counter semantics to the gauge)
+  weight: 25
+- criterion: The response frames the numbers as a drain or recovery following the payment incident rather than only reporting bare values
+  weight: 5


### PR DESCRIPTION
## Why

The current task set is strong on retrieval and aggregation: find the right signal, scope it to the
right window, rank/compare/correlate it. Those tasks mostly reward knowing *where* the data lives.

This one targets a different competency — the failure mode that dominates real observability
mistakes: a query that is syntactically valid, runs without error, and returns a confident number
that answers a different question than the one asked.

## The Task

`tasks-spec/prometheus_query/promql-retry-drain-rate.yaml` asks how fast the payment retry backlog
was shrinking once it started draining (items per minute), and roughly how long the drain took from
peak back to zero.

`service_retry_queue_depth` is a gauge that decreases monotonically while draining. The tempting
query — `rate(service_retry_queue_depth{job="payment-service"}[5m])` — applies counter-reset logic
to it: every lower sample reads as a reset, so `rate()` returns a large **positive** value. An agent
that takes it reports the backlog growing rapidly during the exact window it was draining. That is
an inverted conclusion, not a rounding error. Answering correctly needs `deriv()`/`delta()` or raw
samples.

Three things have to go right: gauge-appropriate math instead of counter semantics, reporting a
drain as a positive rate of decrease rather than a bare negative slope, and locating the peak that
defines the drain window.

## Why It's Worth Adding

- **Complementary.** `promql-retry-backlog-triage` and `dashboard-add-retry-backlog-panels` already
  use this gauge, but only ask for peaks — and `max_over_time` is gauge-safe, so the trap never
  surfaces. Familiar fixture, competency nothing else covers.
- **No fixture cost.** Existing series, unchanged.
- **Deterministic to grade.** The naive and correct answers differ in sign and magnitude class, so
  the rubric can penalize the signature `rate()`-on-a-gauge answer without ambiguity, alongside
  canonical drain-rate and peak-depth fact queries.
- **Natural statement.** Two sentences an on-call engineer would actually type, with nothing in the
  wording hinting at which function to reach for. The discrimination comes from understanding the
  data model, not from parsing the prompt.

## Test Plan

- `mise run setup:sync` — regenerates cleanly (64 tasks)
- `mise run test` — 120 passed, 1 skipped
