### PR TITLE
Highlight the statistically leading group, not just the leader, on comparison pass rates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ files = [
     "reporting/report_paths.py",
     "reporting/run_report.py",
     "reporting/summary.py",
+    "reporting/stats.py",
     "o11y_bench/cli.py",
     "o11y_bench/agento11y_publish.py",
     "o11y_bench/agento11y_suite.py",

--- a/reporting/compare_report.py
+++ b/reporting/compare_report.py
@@ -28,6 +28,7 @@ from .report_data import (
     trial_to_row,
 )
 from .run_report import load_trials
+from .stats import discordant_counts, mcnemar_exact_p, wilson_interval
 from .summary import summarize_trials
 
 JsonDict = dict[str, Any]
@@ -156,6 +157,66 @@ def winner_class(vals: list[float], idx: int, higher_is_better: bool = True) -> 
     return "font-bold text-green-700" if vals[idx] == best else "text-gray-500"
 
 
+# Runs with a p-value above this are treated as indistinguishable from the leader.
+SIGNIFICANCE_ALPHA = 0.05
+
+SUMMARY_LEGEND = (
+    "Bold on Pass^k and Pass@k marks the leading group via exact McNemar, p &gt; 0.05. "
+    "Other rows bold the single best value. 95% CI is a Wilson score interval."
+)
+
+
+def leading_group_mask(
+    jobs: list[JsonDict],
+    rates: list[float],
+    task_key: str,
+    alpha: float = SIGNIFICANCE_ALPHA,
+) -> list[float]:
+    """Return a copy of ``rates`` in which the leading group all carry the best rate.
+
+    The leading group is the highest-scoring run plus every run that an exact McNemar
+    test cannot separate from it. Rewriting those entries to the leader's value makes
+    :func:`winner_class` highlight all of them, without changing how it decides.
+
+    Each run is tested against the leader rather than against its neighbour, because the
+    highlight claims "best of these runs" -- a claim against every other run, not just
+    the runner-up -- and because non-significance does not chain: A may be inseparable
+    from B, and B from C, while A and C are clearly apart.
+
+    ``task_key`` selects the per-task pass/fail mapping the row is about, so the test is
+    paired over the tasks both runs attempted.
+
+    When no run separates from the leader every entry becomes equal, and
+    :func:`winner_class` leaves the whole row unstyled: this benchmark cannot rank these
+    runs on this metric.
+    """
+    if not rates:
+        return []
+
+    best = max(rates)
+    leader_idx = rates.index(best)
+    leader_tasks = jobs[leader_idx][task_key]
+
+    masked = list(rates)
+    for idx, job in enumerate(jobs):
+        if idx == leader_idx:
+            continue
+        only_leader, only_other = discordant_counts(leader_tasks, job[task_key])
+        if mcnemar_exact_p(only_leader, only_other) > alpha:
+            masked[idx] = best
+    return masked
+
+
+def format_rate_cell(rate: float, n_passed: int, n_tasks: int) -> str:
+    """Render a pass rate with its task counts and a 95% Wilson interval."""
+    low, high = wilson_interval(n_passed, n_tasks)
+    return (
+        f"{rate * 100:.1f}% ({n_passed}/{n_tasks})"
+        f'<div class="text-[10px] font-normal text-gray-400">'
+        f"95% CI {low * 100:.1f}&ndash;{high * 100:.1f}%</div>"
+    )
+
+
 def sort_jobs(jobs: list[JsonDict], sort_by: str) -> list[JsonDict]:
     if sort_by == "input":
         return jobs
@@ -224,6 +285,9 @@ def generate_comparison(
 
     pass_hat_rates = [j["pass_hat_rate"] for j in jobs]
     pass_rates = [j["pass_rate"] for j in jobs]
+    # Highlight the leading group rather than the top scorer alone: see leading_group_mask.
+    pass_hat_leaders = leading_group_mask(jobs, pass_hat_rates, "task_consistent")
+    pass_leaders = leading_group_mask(jobs, pass_rates, "task_passed")
     mean_scores = [j["mean_score"] for j in jobs]
     total_costs = [j["total_cost"] for j in jobs]
     total_secs = [j["total_agent_secs"] for j in jobs]
@@ -235,18 +299,18 @@ def generate_comparison(
             summary_row(
                 "Pass^k",
                 [
-                    f"{j['pass_hat_rate'] * 100:.1f}% ({j['tasks_consistent']}/{j['total_tasks']})"
+                    format_rate_cell(j["pass_hat_rate"], j["tasks_consistent"], j["total_tasks"])
                     for j in jobs
                 ],
-                pass_hat_rates,
+                pass_hat_leaders,
             ),
             summary_row(
                 "Pass@k",
                 [
-                    f"{j['pass_rate'] * 100:.1f}% ({j['tasks_passed']}/{j['total_tasks']})"
+                    format_rate_cell(j["pass_rate"], j["tasks_passed"], j["total_tasks"])
                     for j in jobs
                 ],
-                pass_rates,
+                pass_leaders,
             ),
             summary_row("Mean Score", [f"{j['mean_score'] * 100:.1f}%" for j in jobs], mean_scores),
             summary_row(
@@ -342,6 +406,7 @@ def generate_comparison(
         n_tasks=len(all_tasks),
         header_cols=header_cols,
         summary_rows=summary_rows,
+        summary_legend=SUMMARY_LEGEND,
         task_rows=task_rows,
     )
 

--- a/reporting/compare_template.html
+++ b/reporting/compare_template.html
@@ -22,6 +22,7 @@
         </tr></thead>
         <tbody>{summary_rows}</tbody>
       </table>
+      <p class="mt-3 px-3 text-xs text-gray-400 leading-relaxed">{summary_legend}</p>
     </div>
 
     <div class="bg-white rounded-lg border border-gray-200 p-4 mb-6">

--- a/reporting/stats.py
+++ b/reporting/stats.py
@@ -1,0 +1,84 @@
+"""Statistical helpers for the comparison report.
+
+Two tests, both implemented against the standard library only:
+
+- :func:`wilson_interval` -- a binomial proportion confidence interval, for showing how
+  precisely a pass rate is pinned down by a fixed number of tasks.
+- :func:`mcnemar_exact_p` -- an exact two-sided paired test, for asking whether two runs
+  differ by more than chance on the same task set.
+
+Neither ``scipy`` nor ``statsmodels`` is a dependency of this project, so the usual
+``proportion_confint`` / ``contingency_tables.mcnemar`` are unavailable. Both functions
+below are small enough to implement directly, and doing so keeps the dependency set
+unchanged.
+"""
+
+import math
+from collections.abc import Mapping
+
+# Two-sided 95% normal quantile: the z with P(-z < Z < z) = 0.95.
+Z_95 = 1.959963984540054
+
+
+def wilson_interval(successes: int, trials: int, z: float = Z_95) -> tuple[float, float]:
+    """Return the Wilson score interval for ``successes`` out of ``trials``.
+
+    Preferred over the textbook normal (Wald) interval because Wald collapses to zero
+    width at 0% and 100% -- precisely the proportions a small benchmark produces on
+    tasks every model passes or every model fails.
+
+    Returns ``(0.0, 1.0)`` for zero trials: no observation, no information.
+    """
+    if trials < 0 or successes < 0 or successes > trials:
+        raise ValueError(f"invalid counts: {successes} of {trials}")
+    if trials == 0:
+        return (0.0, 1.0)
+
+    n = float(trials)
+    p = successes / n
+    z2 = z * z
+    denominator = 1.0 + z2 / n
+    center = (p + z2 / (2.0 * n)) / denominator
+    margin = (z / denominator) * math.sqrt(p * (1.0 - p) / n + z2 / (4.0 * n * n))
+    return (max(0.0, center - margin), min(1.0, center + margin))
+
+
+def mcnemar_exact_p(only_first: int, only_second: int) -> float:
+    """Return the two-sided p-value of an exact McNemar test.
+
+    ``only_first`` and ``only_second`` are the discordant counts: tasks the first run
+    passed and the second failed, and the reverse. Tasks both runs passed, or both
+    failed, say nothing about which run is better and are excluded by construction --
+    which is why this is a paired test over tasks rather than a comparison of two rates.
+
+    Under the null hypothesis every disagreement is a coin flip, so the number falling
+    one way is Binomial(n, 0.5) with ``n = only_first + only_second``. The p-value is the
+    smaller tail doubled, clamped at 1.0.
+
+    Returns 1.0 when nothing is discordant: the two runs passed exactly the same tasks.
+
+    Exact by construction -- no chi-squared approximation, which is the right call at the
+    disagreement counts a small benchmark produces.
+    """
+    if only_first < 0 or only_second < 0:
+        raise ValueError(f"invalid discordant counts: {only_first}, {only_second}")
+
+    n = only_first + only_second
+    if n == 0:
+        return 1.0
+
+    # n is bounded by the number of tasks, so the exact 2**n term stays small.
+    tail = sum(math.comb(n, i) for i in range(min(only_first, only_second) + 1))
+    return min(1.0, 2.0 * tail / (1 << n))
+
+
+def discordant_counts(first: Mapping[str, bool], second: Mapping[str, bool]) -> tuple[int, int]:
+    """Count tasks that exactly one of two runs passed.
+
+    Returns ``(only_first, only_second)`` over the tasks present in both mappings; tasks
+    missing from either side are skipped, since an unpaired task cannot be compared.
+    """
+    shared = first.keys() & second.keys()
+    only_first = sum(1 for name in shared if first[name] and not second[name])
+    only_second = sum(1 for name in shared if second[name] and not first[name])
+    return (only_first, only_second)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,162 @@
+"""Tests for reporting.stats.
+
+Expected values were produced once with statsmodels 0.14.6 and hardcoded here:
+
+    proportion_confint(k, n, alpha=0.05, method="wilson")
+    contingency_tables.mcnemar([[0, b], [c, 0]], exact=True, correction=False).pvalue
+
+statsmodels is not a dependency of this project, so it is not imported by these tests --
+it was used only to generate the constants below.
+"""
+
+import math
+
+import pytest
+
+from reporting.stats import Z_95, discordant_counts, mcnemar_exact_p, wilson_interval
+
+
+def close(actual, expected):
+    return math.isclose(actual, expected, rel_tol=1e-12, abs_tol=1e-12)
+
+
+# --- Wilson interval -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("successes", "trials", "low", "high"),
+    [
+        # The two cases the Wald interval gets wrong: it reports zero width at both.
+        (0, 10, 0.0, 0.27753279986288926),
+        (10, 10, 0.7224672001371106, 1.0),
+        # Realistic shapes for a benchmark with few tasks.
+        (32, 63, 0.38762886274954733, 0.6273319118601534),
+        (50, 63, 0.6783018567138666, 0.8752468038450618),
+        (46, 63, 0.6097009078044822, 0.82416155587684),
+        (1, 63, 0.002807494213869284, 0.08458525459438399),
+    ],
+)
+def test_wilson_matches_statsmodels(successes, trials, low, high):
+    got_low, got_high = wilson_interval(successes, trials)
+    assert close(got_low, low)
+    assert close(got_high, high)
+
+
+def test_wilson_is_symmetric_under_complement():
+    """Swapping successes for failures mirrors the interval about 0.5."""
+    low, high = wilson_interval(31, 63)
+    mirror_low, mirror_high = wilson_interval(63 - 31, 63)
+    assert close(low, 1.0 - mirror_high)
+    assert close(high, 1.0 - mirror_low)
+
+
+def test_wilson_with_no_trials_spans_everything():
+    assert wilson_interval(0, 0) == (0.0, 1.0)
+
+
+def test_wilson_stays_inside_the_unit_interval():
+    for trials in range(1, 40):
+        for successes in range(trials + 1):
+            low, high = wilson_interval(successes, trials)
+            assert 0.0 <= low <= high <= 1.0
+
+
+def test_wilson_narrows_as_trials_grow():
+    """Same proportion, more tasks, tighter interval."""
+    small_low, small_high = wilson_interval(5, 10)
+    large_low, large_high = wilson_interval(50, 100)
+    assert (large_high - large_low) < (small_high - small_low)
+
+
+def test_wilson_rejects_impossible_counts():
+    with pytest.raises(ValueError):
+        wilson_interval(11, 10)
+    with pytest.raises(ValueError):
+        wilson_interval(-1, 10)
+    with pytest.raises(ValueError):
+        wilson_interval(1, -10)
+
+
+def test_z_95_is_the_two_sided_95_percent_quantile():
+    assert close(Z_95, 1.959963984540054)
+
+
+# --- Exact McNemar ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("only_first", "only_second", "p_value"),
+    [
+        (4, 0, 0.125),
+        (9, 1, 0.021484375),
+        (13, 3, 0.021270751953125),
+        (18, 6, 0.022655844688415527),
+        (7, 2, 0.1796875),
+    ],
+)
+def test_mcnemar_matches_statsmodels(only_first, only_second, p_value):
+    assert close(mcnemar_exact_p(only_first, only_second), p_value)
+
+
+def test_mcnemar_with_no_disagreement_is_one():
+    """Two runs that passed exactly the same tasks are indistinguishable, not different."""
+    assert mcnemar_exact_p(0, 0) == 1.0
+
+
+def test_mcnemar_doubling_is_clamped_at_one():
+    """A one-all split doubles to 1.5 before clamping; a p-value above 1.0 is nonsense."""
+    assert mcnemar_exact_p(1, 1) == 1.0
+
+
+def test_mcnemar_is_symmetric():
+    """The test asks whether the runs differ, not which one is ahead."""
+    assert close(mcnemar_exact_p(9, 1), mcnemar_exact_p(1, 9))
+
+
+def test_mcnemar_needs_a_net_gap_of_six_on_a_clean_sweep():
+    """The floor on separability, and the reason a naive gate would empty the board.
+
+    On a perfect sweep -- every task the loser passed, the winner passed too -- a net gap
+    of five still cannot reach p < 0.05, and six is the first that can. Leaders separated
+    by a handful of tasks therefore cannot be told apart on a benchmark this size.
+    """
+    assert mcnemar_exact_p(4, 0) == 0.125
+    assert mcnemar_exact_p(5, 0) == 0.0625
+    assert mcnemar_exact_p(6, 0) == 0.03125
+    assert mcnemar_exact_p(5, 0) > 0.05
+    assert mcnemar_exact_p(6, 0) < 0.05
+
+
+def test_mcnemar_rejects_negative_counts():
+    with pytest.raises(ValueError):
+        mcnemar_exact_p(-1, 3)
+    with pytest.raises(ValueError):
+        mcnemar_exact_p(3, -1)
+
+
+# --- Discordant counts -----------------------------------------------------------
+
+
+def test_discordant_counts_ignores_agreement():
+    first = {"a": True, "b": True, "c": False, "d": False}
+    second = {"a": True, "b": False, "c": True, "d": False}
+    assert discordant_counts(first, second) == (1, 1)
+
+
+def test_discordant_counts_skips_unpaired_tasks():
+    """A task only one run attempted cannot be paired, so it carries no vote."""
+    first = {"a": True, "only_in_first": True}
+    second = {"a": False, "only_in_second": True}
+    assert discordant_counts(first, second) == (1, 0)
+
+
+def test_discordant_counts_reverses_with_argument_order():
+    first = {"a": True, "b": False, "c": True}
+    second = {"a": False, "b": True, "c": True}
+    assert discordant_counts(first, second) == (1, 1)
+    assert discordant_counts(second, first) == (1, 1)
+
+
+def test_discordant_counts_of_identical_runs_is_empty():
+    run = {"a": True, "b": False, "c": True}
+    assert discordant_counts(run, dict(run)) == (0, 0)


### PR DESCRIPTION
The Pass^k and Pass@k rows highlight the single best run. The problem is, on a benchmark this small, runs that look far apart on count can be a coin flip depending on where they disagree.

This highlights the top run plus every run an exact McNemar test cannot separate from it (p > 0.05). It also prints a 95% Wilson interval beside each rate so the precision behind the number is visible. The table already bolds two cells when two runs tie exactly. This widens that from "exactly equal" to "not distinguishable statistically".

Here's the rendering before:
<img width="1074" height="762" alt="SetABefore" src="https://github.com/user-attachments/assets/f08e64f2-f25f-4120-9f60-3ec146b32aed" />

Here's the rendering after:
<img width="1074" height="884" alt="SetAAfter" src="https://github.com/user-attachments/assets/8e370b54-2699-48d5-ae9e-1ccfedebab50" />

winner_class and summary_row are unchanged, just the values that get handed to them are. When no runs separate, the row renders unstyled.

Adds reporting/stats.py implementing the Wilson interval and exact McNemar with the standard library since the project doesn't depend on statsmodels or scipy.

Both screenshots are rendered from submissions in: https://huggingface.co/datasets/grafanalabs/o11y-bench-leaderboard

The reproduce command:
```bash
S=submissions/o11y-bench/1.0
uv run python -m reporting.compare_report \
  --job-dir $S/o11y-bench__anthropic-claude-opus-4-8/anthropic-claude-opus-4-8-high-k3 \
  --job-dir $S/o11y-bench__anthropic-claude-opus-4-7/anthropic-claude-opus-4-7-off-k3 \
  --job-dir $S/o11y-bench__anthropic-claude-opus-5/anthropic-claude-opus-5-high-k3 \
  --job-dir $S/o11y-bench__anthropic-claude-opus-4-7/anthropic-claude-opus-4-7-high-k3 \
  --job-dir $S/o11y-bench__anthropic-claude-sonnet-4-6/anthropic-claude-sonnet-4-6-high-k3 \
  --job-dir $S/o11y-bench__anthropic-claude-opus-4-6/anthropic-claude-opus-4-6-off-k3 \
  --job-dir $S/o11y-bench__anthropic-claude-haiku-4-5-20251001/anthropic-claude-haiku-4-5-20251001-off-k3 \
  --job-dir $S/o11y-bench__openai-gpt-5-4-mini/openai-gpt-5-4-mini-off-k3 \
  --sort-by pass-hat
```

26 tests in tests/test_stats.py ensure the stats.py functions are in order.